### PR TITLE
frontend: update for PyCon AU 2026

### DIFF
--- a/frontend/src/access-denied.html
+++ b/frontend/src/access-denied.html
@@ -9,7 +9,7 @@
   <body class="min-h-screen bg-white">
     <header class="container mx-auto px-4 py-8">
       <div class="flex">
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
     </header>
 
@@ -23,7 +23,7 @@
 
           <p class="text-2xl font-thin">
             You can find the link to login from your order link, which you can find in your email or you can
-            <a class="text-blue-600 hover:underline" href="https://pretix.eu/pyconau/2025/resend/"
+            <a class="text-blue-600 hover:underline" href="https://pretix.eu/pyconau/2026/resend/"
               >resend your order link</a
             >.
           </p>
@@ -31,7 +31,7 @@
           <h3 class="text-3xl font-thin pt-8">Don't have a ticket?</h3>
 
           <p class="text-2xl font-thin">
-            <a class="text-blue-600 hover:underline" href="https://pretix.eu/pyconau/2025/">Purchase your ticket now</a
+            <a class="text-blue-600 hover:underline" href="https://pretix.eu/pyconau/2026/">Purchase your ticket now</a
             >.
           </p>
         </div>

--- a/frontend/src/after-attend.html
+++ b/frontend/src/after-attend.html
@@ -9,7 +9,7 @@
     <header class="container mx-auto px-4 py-8">
       <div class="flex">
         <!-- <a class="flex-initial text-2xl p-1 font-bold text-green-500 hover:bg-green-500 hover:text-white hover:rounded-lg" href="attend.html">🔙</a> -->
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
       <h2 class="text-4xl font-thin text-green-500" id="room-name">Available Streams</h2>
     </header>
@@ -20,7 +20,7 @@
         <div class="flex-auto space-y-4">
           <h2 class="text-4xl font-thin">Talks are done</h2>
 
-          <p class="text-2xl font-thin">Thanks for joining us for PyCon AU 2025! We hope you enjoyed the conference.</p>
+          <p class="text-2xl font-thin">Thanks for joining us for PyCon AU 2026! We hope you enjoyed the conference.</p>
 
           <p class="text-2xl font-thin">
             If you missed any of the talks, you can watch them on our
@@ -30,7 +30,7 @@
 
           <p class="text-2xl font-thin">
             For now, maybe head back to
-            <a href="https://2025.pycon.org.au" class="text-blue-600 hover:underline">PyCon AU 2025 website.</a>
+            <a href="https://2026.pycon.org.au" class="text-blue-600 hover:underline">PyCon AU 2026 website.</a>
           </p>
 
           <p class="text-2xl font-thin">Thanks again for joining us, and we hope to see you next year!</p>

--- a/frontend/src/after-play.html
+++ b/frontend/src/after-play.html
@@ -9,7 +9,7 @@
     <header class="container mx-auto px-4 py-8">
       <div class="flex">
         <!-- <a class="flex-initial text-2xl p-1 font-bold text-green-500 hover:bg-green-500 hover:text-white hover:rounded-lg" href="attend.html">🔙</a> -->
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
       <h2 class="text-4xl font-thin text-green-500" id="room-name">Available Streams</h2>
     </header>
@@ -20,7 +20,7 @@
         <div class="flex-auto space-y-4">
           <h2 class="text-4xl font-thin">Talks are done</h2>
 
-          <p class="text-2xl font-thin">Thanks for joining us for PyCon AU 2025! We hope you enjoyed the conference.</p>
+          <p class="text-2xl font-thin">Thanks for joining us for PyCon AU 2026! We hope you enjoyed the conference.</p>
 
           <p class="text-2xl font-thin">
             If you missed any of the talks, you can watch them on our
@@ -30,7 +30,7 @@
 
           <p class="text-2xl font-thin">
             For now, maybe head back to
-            <a href="https://2025.pycon.org.au" class="text-blue-600 hover:underline">PyCon AU 2025 website.</a>
+            <a href="https://2026.pycon.org.au" class="text-blue-600 hover:underline">PyCon AU 2026 website.</a>
           </p>
 
           <p class="text-2xl font-thin">Thanks again for joining us, and we hope to see you next year!</p>

--- a/frontend/src/attend.html
+++ b/frontend/src/attend.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="./css/attend.css" rel="stylesheet" />
-    <title>PyCon AU 2025</title>
+    <title>PyCon AU 2026</title>
     <!-- <link href="./css/dynamic.css" rel="stylesheet" /> -->
   </head>
   <body class="min-h-screen bg-white">
     <header class="container mx-auto px-4 py-8">
       <div class="flex">
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
       <h2 class="text-4xl font-thin text-green-500" id="room-name">Available Streams</h2>
     </header>
@@ -28,7 +28,7 @@
       <ul id="room-list" class="space-y-4"></ul>
       <p class="text-lg">
         See the
-        <a href="https://2025.pycon.org.au/program" class="text-blue-600 hover:underline">program</a> for what's on.
+        <a href="https://2026.pycon.org.au/program" class="text-blue-600 hover:underline">program</a> for what's on.
       </p>
     </main>
 

--- a/frontend/src/hls-not-supported.html
+++ b/frontend/src/hls-not-supported.html
@@ -14,7 +14,7 @@
           href="attend.html"
           >🔙</a
         >
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2023</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
     </header>
 

--- a/frontend/src/play.html
+++ b/frontend/src/play.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="./css/attend.css" rel="stylesheet" />
-    <title>PyCon AU 2025</title>
+    <title>PyCon AU 2026</title>
     <!-- <link href="./css/dynamic.css" rel="stylesheet" /> -->
   </head>
   <body class="min-h-screen bg-white">
@@ -15,7 +15,7 @@
           href="attend.html"
           >🔙</a
         >
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
       <h2 class="text-4xl font-thin text-green-500" id="room-name">&nbsp;</h2>
     </header>
@@ -52,7 +52,7 @@
           <p id="offline-title" class="text-4xl font-thin">This stream is offline right now.</p>
           <p class="text-2xl font-thin">
             You might want to check
-            <a href="https://2025.pycon.org.au/program/list/" class="text-blue-600 hover:underline">the program</a> or
+            <a href="https://2026.pycon.org.au/program/list/" class="text-blue-600 hover:underline">the program</a> or
             <a href="attend.html" class="text-blue-600 hover:underline">the other streams</a>.
           </p>
           <p class="text-2xl font-thin">

--- a/frontend/src/stream-not-found.html
+++ b/frontend/src/stream-not-found.html
@@ -14,7 +14,7 @@
           href="attend.html"
           >🔙</a
         >
-        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2025</h1>
+        <h1 class="flex-auto text-4xl font-bold text-green-500">PyCon AU 2026</h1>
       </div>
     </header>
 


### PR DESCRIPTION
Bumps every conference reference on the frontend from **2025 → 2026** across 7 pages, following the annual update pattern.

## Changes
- **Titles & headings** — `attend`, `play`, `access-denied`, `stream-not-found`, `after-attend`, `after-play`, `hls-not-supported`
- **Program links** — `https://2026.pycon.org.au/program` (and `/program/list/`)
- **Website links** — `https://2026.pycon.org.au`
- **Ticket links** — `https://pretix.eu/pyconau/2026/` and `.../2026/resend/`
- **Body copy** — "Thanks for joining us for PyCon AU 2026!"
- Also fixes a stale `PyCon AU 2023` heading in `hls-not-supported.html`

The `@PyConAU` YouTube handle (no year) is unchanged.

## Verification
- Zero remaining `2025`/`2023` references in `frontend/src`
- 7 files changed, 17 insertions / 17 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)