### PR TITLE
Add a stream admin UI for editing multiview tags during an event

### DIFF
--- a/backend-lambda/ci/pr.sh
+++ b/backend-lambda/ci/pr.sh
@@ -22,6 +22,10 @@ if ! s3_object_exists $LAMBDA_BUCKET $object; then
   pnpm install --frozen-lockfile
   end_group
 
+  start_group "Test"
+  pnpm test
+  end_group
+
   start_group "Building"
   pnpm run build
   end_group

--- a/backend-lambda/jest.config.js
+++ b/backend-lambda/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  // dist/ holds a copy of package.json after a build, which jest's haste map
+  // reports as a duplicate of the real one.
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  // @swc/jest rather than ts-jest: ts-jest 29 cannot use the TypeScript 7
+  // compiler API this project pins. Matches frontend/jest.config.js.
+  transform: {
+    '^.+\\.ts$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript' },
+          target: 'es2020',
+        },
+      },
+    ],
+  },
+};

--- a/backend-lambda/package.json
+++ b/backend-lambda/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "compile": "ts-auto-guard --debug && tsc",
     "watch": "tsc -w",
+    "test": "jest",
     "prestart": "pnpm run compile",
     "start": "node dist/src/index.js",
     "lint": "eslint --ext .ts ./",
@@ -32,6 +33,8 @@
     "set-cookie-parser": "^2.7.2"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.46",
+    "@swc/jest": "^0.2.39",
     "@types/aws-lambda": "^8.10.162",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",

--- a/backend-lambda/package.json
+++ b/backend-lambda/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "ts-auto-guard --debug && tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "ts-auto-guard --debug && jest",
     "prestart": "pnpm run compile",
     "start": "node dist/src/index.js",
     "lint": "eslint --ext .ts ./",

--- a/backend-lambda/pnpm-lock.yaml
+++ b/backend-lambda/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
         specifier: ^2.7.2
         version: 2.7.2
     devDependencies:
+      '@swc/core':
+        specifier: ^1.15.46
+        version: 1.15.46
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.46)
       '@types/aws-lambda':
         specifier: ^8.10.162
         version: 8.10.162
@@ -462,6 +468,10 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/create-cache-key-function@30.4.1':
+    resolution: {integrity: sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -601,6 +611,105 @@ packages:
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
+
+  '@swc/core-darwin-arm64@1.15.46':
+    resolution: {integrity: sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.46':
+    resolution: {integrity: sha512-4Tj4ppVIPCmUMpmGFiGtyEriwLyJ+yi/US4WfBrP/ok8COGddDZXLEzQETnKyK46mjvr1v0jevrS23zjoff7vA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.46':
+    resolution: {integrity: sha512-i8tUGnNjyOgMmfmgFSg4aeJLQoFyfpIHK5FjpQAwpRyQIqEUB2w1e8zIDQzY1WhOxx8NoS1S5iUL813Un4Sf5A==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.46':
+    resolution: {integrity: sha512-c0OnhqzdhfOvv6qhNCcByepB+sNYOGZyhtr2Qa6ZCHvAWTYhSRw4j/u92Stue9PbZ/6q74b9nHzi76+kVzqQHQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.46':
+    resolution: {integrity: sha512-imyRpNEcUzFQFV2LE4jL68ErvmKEuZCbvZru77iQREunJ+bR4i658cupTgtG1mLYM3F1Tzy3Sb9xYb02KghWTg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.46':
+    resolution: {integrity: sha512-ctEfcl/HcUeomK33cbySiHZm98GEDIxTm1EkpBsYCiHxElYBzvTXVeuQT2YwbUXn9XCrjiw4ipyUNk33k26qRg==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.46':
+    resolution: {integrity: sha512-DxlMdnt84TtRVTv7WL/thWyz9+QU8QZNNoAP9rrk0P68LziuhfePp8MjQ44zIprpTHTsEwyziIuGUUN5iSC1bQ==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.46':
+    resolution: {integrity: sha512-SKxI7J6t90XPl8hRUqtJi9NfGdunN/E/vZMc7Bc0figeRdOPDBT+Tm8g7cx9xM0T0mewh2l+8dewa3Am27/P+A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.46':
+    resolution: {integrity: sha512-qj9T6B7bosI0VEsrWOVXZN1OXxS8Tp63ywyrLxNdOycnUtLdkgYcoBsN5y8ImnDDsnwrEWZOy1e+J4xSe7mA3Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.46':
+    resolution: {integrity: sha512-8p7l4c3LU+eA5g9Et1JPhNeMC1oQwXTGU+uah8DPIBX7YXzqswvaBtyKVmXefVGi/DJU1x3YJsc3mbAp9aWzSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.46':
+    resolution: {integrity: sha512-tUEnfr3Bn9u6FOjUb3PN9p+09qZC2j+wNDLKHzXXZn22rqGcUqR/ohCRSS+nG9B9+X+U+3FewNEHJkTmdIvMjQ==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.46':
+    resolution: {integrity: sha512-Vux7UDzBJYQggSuPfcl2w9iu+IJpgpRCxHzgCaVkELnAXAE4XZMOTX9HNcaNiwfeIDqdu2rkr69RuDm6wY8neA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.46':
+    resolution: {integrity: sha512-Ri3em2mBpq3h2zSPliCYl63otDGqek8PPEfv2nWgRQEbZ/VBCNyypVTVQ6cEbTCXBhy+WE2T3fQb08moIyuYaw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/jest@0.2.39':
+    resolution: {integrity: sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
+
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -2097,6 +2206,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
@@ -3414,6 +3526,10 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/create-cache-key-function@30.4.1':
+    dependencies:
+      '@jest/types': 30.4.1
+
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment@30.4.1':
@@ -3631,6 +3747,73 @@ snapshots:
   '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/core-darwin-arm64@1.15.46':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.46':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.46':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.46':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.46':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.46':
+    optional: true
+
+  '@swc/core@1.15.46':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.27
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.46
+      '@swc/core-darwin-x64': 1.15.46
+      '@swc/core-linux-arm-gnueabihf': 1.15.46
+      '@swc/core-linux-arm64-gnu': 1.15.46
+      '@swc/core-linux-arm64-musl': 1.15.46
+      '@swc/core-linux-ppc64-gnu': 1.15.46
+      '@swc/core-linux-s390x-gnu': 1.15.46
+      '@swc/core-linux-x64-gnu': 1.15.46
+      '@swc/core-linux-x64-musl': 1.15.46
+      '@swc/core-win32-arm64-msvc': 1.15.46
+      '@swc/core-win32-ia32-msvc': 1.15.46
+      '@swc/core-win32-x64-msvc': 1.15.46
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/jest@0.2.39(@swc/core@1.15.46)':
+    dependencies:
+      '@jest/create-cache-key-function': 30.4.1
+      '@swc/core': 1.15.46
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
+
+  '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -5319,6 +5502,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonwebtoken@9.0.3:
     dependencies:

--- a/backend-lambda/pnpm-workspace.yaml
+++ b/backend-lambda/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - .
 allowBuilds:
+  # The native binary comes from a platform-specific optional dependency, not the
+  # build script, so jest runs fine without it.
+  '@swc/core': false
   unrs-resolver: true
 minimumReleaseAge: 1440

--- a/backend-lambda/src/handlers/admin/AdminStream.ts
+++ b/backend-lambda/src/handlers/admin/AdminStream.ts
@@ -1,0 +1,18 @@
+export const TAG_TITLE = 'multiview:title';
+export const TAG_ORDER = 'multiview:order';
+export const TAG_SHOW = 'multiview:show';
+export const TAG_DEMO = 'multiview:demo';
+
+export type AdminTags = Record<string, string>;
+
+/** One SSM parameter under /multiview/mux/. Never carries the parameter value. */
+export interface AdminStream {
+  id: string;
+  tags: AdminTags;
+}
+
+/** Tags to write, and tag keys to delete. */
+export interface TagEditPlan {
+  set: AdminTags;
+  remove: string[];
+}

--- a/backend-lambda/src/handlers/admin/applyTagEdits.ts
+++ b/backend-lambda/src/handlers/admin/applyTagEdits.ts
@@ -1,0 +1,39 @@
+import { SSM } from '@aws-sdk/client-ssm';
+import { failure, Result, success } from '../../helpers/result';
+import { TagEditPlan } from './AdminStream';
+
+/**
+ * SSM raises InvalidResourceId when the tag target does not exist — confirmed
+ * against the declared exceptions for AddTagsToResource, RemoveTagsFromResource
+ * and ListTagsForResource. It is not ParameterNotFound, which belongs to the
+ * GetParameter family.
+ */
+export const isMissingParameterError = (err: Error): boolean => err.name === 'InvalidResourceId';
+
+/**
+ * Applies a plan with up to two SSM calls. Clearing a tag is a RemoveTagsFromResource
+ * call, not an AddTagsToResource with an empty value.
+ *
+ * `plan.remove` is expected to have been filtered to keys that exist on the
+ * parameter — see readRoomTags. Whether SSM treats removing an absent key as a
+ * no-op is undocumented, so the caller does not rely on it either way.
+ */
+export const applyTagEdits = async (ssm: SSM, roomId: string, plan: TagEditPlan): Promise<Result<Error, void>> => {
+  const ResourceId = `/multiview/mux/${roomId}`;
+
+  const tags = Object.entries(plan.set).map(([Key, Value]) => ({ Key, Value }));
+
+  try {
+    if (tags.length > 0) {
+      await ssm.addTagsToResource({ ResourceType: 'Parameter', ResourceId, Tags: tags });
+    }
+
+    if (plan.remove.length > 0) {
+      await ssm.removeTagsFromResource({ ResourceType: 'Parameter', ResourceId, TagKeys: plan.remove });
+    }
+  } catch (err) {
+    return failure(err as Error);
+  }
+
+  return success(undefined);
+};

--- a/backend-lambda/src/handlers/admin/listStreamsFromSSM.ts
+++ b/backend-lambda/src/handlers/admin/listStreamsFromSSM.ts
@@ -1,0 +1,69 @@
+import { GetParametersByPathResult } from '@aws-sdk/client-ssm';
+import PQueue from '@esm2cjs/p-queue';
+import { notUndefined } from '../../helpers/notUndefined';
+import { failure, isFailure, isSuccess, Result, success, successValue } from '../../helpers/result';
+import { ssm } from '../../helpers/ssm';
+import { getOrderFromTag } from '../rooms/getOrderFromTag';
+import { getRoomWithTags, RoomWithTags } from '../rooms/getRoomWithTags';
+import { AdminStream, AdminTags, TAG_ORDER } from './AdminStream';
+
+const path = '/multiview/mux/';
+
+const tagsQueue = new PQueue({ concurrency: 4 });
+
+const orderOf = (tags: AdminTags): number => getOrderFromTag(tags[TAG_ORDER], Number.MAX_SAFE_INTEGER);
+
+/**
+ * Every parameter under /multiview/mux/ with its tags, unfiltered — unlike
+ * getRoomsFromSSM, which drops anything without multiview:show=true. The admin UI
+ * must be able to see (and un-hide) hidden rooms.
+ *
+ * Only Name is read from the response. The parameter values are Mux token secrets
+ * and must never reach a client.
+ */
+export const listStreamsFromSSM = async (): Promise<Result<Error, AdminStream[]>> => {
+  const names: string[] = [];
+  let nextToken: string | undefined = undefined;
+
+  // getParametersByPath returns 10 per page by default. getRoomsFromSSM does not
+  // paginate; an admin list that silently truncates would be a bad failure mode.
+  do {
+    // Annotated because nextToken is assigned from page, which is derived from a
+    // call taking nextToken — without this the inference is circular (TS7022).
+    const page: GetParametersByPathResult = await ssm.getParametersByPath({ Path: path, NextToken: nextToken });
+
+    if (page.Parameters == null) {
+      return failure(new Error('Unexpected AWS response'));
+    }
+
+    names.push(...page.Parameters.map(({ Name }) => Name).filter(notUndefined));
+
+    nextToken = page.NextToken;
+  } while (nextToken !== undefined);
+
+  // PQueue.add resolves to `Result | void`, so the null check is not optional —
+  // this mirrors getRoomsFromSSM rather than using `??`, which does not narrow a
+  // `void` union cleanly under strict.
+  const settled = await Promise.all(names.map((name) => tagsQueue.add(() => getRoomWithTags(ssm, name))));
+
+  const maybeStreams = settled.map((r) => {
+    if (r == null) {
+      return failure<Error, RoomWithTags>(new Error('Cancelled'));
+    }
+    return r;
+  });
+
+  const errors = maybeStreams.filter(isFailure).map(({ value }) => value);
+
+  if (errors.length > 0) {
+    return failure(new Error(`${errors.length} errors fetching tags. ${errors.map((e) => e.message).join(', ')}`));
+  }
+
+  const streams = maybeStreams
+    .filter(isSuccess)
+    .map(successValue)
+    .map(({ id, tags }) => ({ id: id.substring(path.length), tags }))
+    .sort((first, second) => orderOf(first.tags) - orderOf(second.tags) || first.id.localeCompare(second.id));
+
+  return success(streams);
+};

--- a/backend-lambda/src/handlers/admin/parseTagEdits.test.ts
+++ b/backend-lambda/src/handlers/admin/parseTagEdits.test.ts
@@ -1,0 +1,85 @@
+import { isFailure, isSuccess, successValue } from '../../helpers/result';
+import { TAG_DEMO, TAG_ORDER, TAG_SHOW, TAG_TITLE } from './AdminStream';
+import { parseTagEdits } from './parseTagEdits';
+
+const demos = ['offline', 'fake-stream'];
+
+const planFor = (request: Parameters<typeof parseTagEdits>[0]) => {
+  const result = parseTagEdits(request, demos);
+  if (!isSuccess(result)) {
+    throw new Error(`Expected success, got failure: ${result.value.message}`);
+  }
+  return successValue(result);
+};
+
+describe('parseTagEdits', () => {
+  it('returns an empty plan for an empty request', () => {
+    expect(planFor({})).toEqual({ set: {}, remove: [] });
+  });
+
+  it('writes order from a number', () => {
+    expect(planFor({ order: 5 }).set[TAG_ORDER]).toBe('5');
+  });
+
+  it('writes order from a numeric string', () => {
+    expect(planFor({ order: '5' }).set[TAG_ORDER]).toBe('5');
+  });
+
+  it('accepts a negative order', () => {
+    expect(planFor({ order: '-2' }).set[TAG_ORDER]).toBe('-2');
+  });
+
+  it('rejects a partially numeric order rather than truncating it', () => {
+    expect(isFailure(parseTagEdits({ order: '12abc' }, demos))).toBe(true);
+  });
+
+  it('rejects a non-integer order', () => {
+    expect(isFailure(parseTagEdits({ order: 1.5 }, demos))).toBe(true);
+  });
+
+  it('rejects an empty order', () => {
+    expect(isFailure(parseTagEdits({ order: '' }, demos))).toBe(true);
+  });
+
+  it('writes show as the literal string true', () => {
+    expect(planFor({ show: true }).set[TAG_SHOW]).toBe('true');
+  });
+
+  it('writes show as the literal string false', () => {
+    expect(planFor({ show: false }).set[TAG_SHOW]).toBe('false');
+  });
+
+  it('trims the title', () => {
+    expect(planFor({ title: '  Room One  ' }).set[TAG_TITLE]).toBe('Room One');
+  });
+
+  it('removes the title tag when the title is blank', () => {
+    const plan = planFor({ title: '   ' });
+    expect(plan.remove).toContain(TAG_TITLE);
+    expect(plan.set[TAG_TITLE]).toBeUndefined();
+  });
+
+  it('accepts a known demo', () => {
+    expect(planFor({ demo: 'fake-stream' }).set[TAG_DEMO]).toBe('fake-stream');
+  });
+
+  it('rejects an unknown demo', () => {
+    expect(isFailure(parseTagEdits({ demo: 'nope' }, demos))).toBe(true);
+  });
+
+  it('removes the demo tag when demo is null', () => {
+    const plan = planFor({ demo: null });
+    expect(plan.remove).toContain(TAG_DEMO);
+    expect(plan.set[TAG_DEMO]).toBeUndefined();
+  });
+
+  it('handles a full edit in one plan', () => {
+    const plan = planFor({ title: 'Main Hall', order: 1, show: true, demo: null });
+    expect(plan.set).toEqual({
+      [TAG_TITLE]: 'Main Hall',
+      [TAG_ORDER]: '1',
+      [TAG_SHOW]: 'true',
+    });
+    expect(plan.remove).toEqual([TAG_DEMO]);
+  });
+});

--- a/backend-lambda/src/handlers/admin/parseTagEdits.ts
+++ b/backend-lambda/src/handlers/admin/parseTagEdits.ts
@@ -1,0 +1,56 @@
+import { failure, Result, success } from '../../helpers/result';
+import { AdminTagEditRequest } from '../../types';
+import { TAG_DEMO, TAG_ORDER, TAG_SHOW, TAG_TITLE, TagEditPlan } from './AdminStream';
+
+const INTEGER = /^-?\d+$/;
+
+/**
+ * Validates a tag edit request and turns it into tags to write and tag keys to
+ * delete. Pure: does no IO. `validDemos` comes from handlers/mux/demos.ts so the
+ * accepted values cannot drift from the ones the player understands.
+ */
+export const parseTagEdits = (request: AdminTagEditRequest, validDemos: string[]): Result<Error, TagEditPlan> => {
+  const set: Record<string, string> = {};
+  const remove: string[] = [];
+
+  if (request.title !== undefined) {
+    const title = request.title.trim();
+    if (title.length === 0) {
+      // getRoomWithTags discards falsy tag values, so an empty title is a removal.
+      remove.push(TAG_TITLE);
+    } else {
+      set[TAG_TITLE] = title;
+    }
+  }
+
+  if (request.order !== undefined) {
+    if (typeof request.order === 'number') {
+      if (!Number.isInteger(request.order)) {
+        return failure(new Error('order must be a whole number'));
+      }
+      set[TAG_ORDER] = String(request.order);
+    } else {
+      // parseInt('12abc') is 12, so test the whole string before converting.
+      if (!INTEGER.test(request.order.trim())) {
+        return failure(new Error('order must be a whole number'));
+      }
+      set[TAG_ORDER] = String(parseInt(request.order.trim(), 10));
+    }
+  }
+
+  if (request.show !== undefined) {
+    set[TAG_SHOW] = request.show ? 'true' : 'false';
+  }
+
+  if (request.demo !== undefined) {
+    if (request.demo === null) {
+      remove.push(TAG_DEMO);
+    } else if (!validDemos.includes(request.demo)) {
+      return failure(new Error(`demo must be one of ${validDemos.join(', ')}`));
+    } else {
+      set[TAG_DEMO] = request.demo;
+    }
+  }
+
+  return success({ set, remove });
+};

--- a/backend-lambda/src/handlers/admin/readRoomTags.ts
+++ b/backend-lambda/src/handlers/admin/readRoomTags.ts
@@ -1,0 +1,23 @@
+import { SSM } from '@aws-sdk/client-ssm';
+import { failure, isFailure, Result, success, successValue } from '../../helpers/result';
+import { getRoomWithTags } from '../rooms/getRoomWithTags';
+import { AdminTags } from './AdminStream';
+
+/**
+ * Current tags for one room. Unlike getRoomWithTags this catches, so a missing
+ * parameter surfaces as a failure carrying InvalidResourceId rather than
+ * throwing — which lets the handler answer 404 instead of 500.
+ */
+export const readRoomTags = async (ssm: SSM, roomId: string): Promise<Result<Error, AdminTags>> => {
+  try {
+    const maybeRoom = await getRoomWithTags(ssm, `/multiview/mux/${roomId}`);
+
+    if (isFailure(maybeRoom)) {
+      return maybeRoom;
+    }
+
+    return success(successValue(maybeRoom).tags);
+  } catch (err) {
+    return failure(err as Error);
+  }
+};

--- a/backend-lambda/src/handlers/admin/refreshAfterEdit.ts
+++ b/backend-lambda/src/handlers/admin/refreshAfterEdit.ts
@@ -1,0 +1,55 @@
+import { isFailure, Result, success, successValue } from '../../helpers/result';
+import { getRoomsFromDynamo } from '../rooms/getRoomsFromDynamo';
+import { getStreamStateFromDynamo } from '../mux/getStreamStateFromDynamo';
+import { getAblyClient } from '../ably/getAblyClient';
+import { StreamStateWithTitle } from '../mux/StreamState';
+
+const CHANNEL = 'mux-monitor.aws.nextdayvideo.com.au';
+
+/**
+ * A tag edit can change both caches: multiview:show and multiview:order feed
+ * rooms/all, while multiview:title and multiview:demo feed stream/<roomId>.
+ * /api/refresh only does the former, so both are forced here.
+ *
+ * The Ably publish is best-effort. By the time it runs the tags are written and
+ * both caches are correct, so a publish failure must not be reported as a failed
+ * save.
+ */
+export const refreshAfterEdit = async (
+  tableName: string,
+  roomId: string,
+): Promise<Result<Error, StreamStateWithTitle>> => {
+  const maybeAblyTask = getAblyClient();
+
+  const maybeRooms = await getRoomsFromDynamo(tableName, true);
+  if (isFailure(maybeRooms)) {
+    return maybeRooms;
+  }
+
+  const maybeState = await getStreamStateFromDynamo(tableName, roomId, true);
+  if (isFailure(maybeState)) {
+    return maybeState;
+  }
+
+  const state = successValue(maybeState);
+
+  const maybeAbly = await maybeAblyTask;
+
+  if (isFailure(maybeAbly)) {
+    console.log('Failed to initialise ably', maybeAbly.value);
+  } else {
+    const ably = successValue(maybeAbly);
+
+    if (ably == undefined) {
+      console.log('Not notifying ably (ABLY_SERVER_KEY not set)');
+    } else {
+      try {
+        await ably.channels.get(CHANNEL).publish('stream', { roomId, why: 'admin-edit', ...state });
+      } catch (err) {
+        console.log('Failed to publish to ably', err);
+      }
+    }
+  }
+
+  return success(state);
+};

--- a/backend-lambda/src/handlers/adminListStreams.ts
+++ b/backend-lambda/src/handlers/adminListStreams.ts
@@ -1,0 +1,32 @@
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { catchErrors } from '../helpers/catchErrors';
+import { accessDenied, response } from '../helpers/response';
+import { isFailure, successValue } from '../helpers/result';
+import { requireRole } from '../helpers/requireRole';
+import { demos } from './mux/demos';
+import { listStreamsFromSSM } from './admin/listStreamsFromSSM';
+
+export const adminListStreams: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
+  if (!(await requireRole(event))) {
+    return accessDenied();
+  }
+
+  const maybeStreams = await listStreamsFromSSM();
+
+  if (isFailure(maybeStreams)) {
+    throw maybeStreams.value;
+  }
+
+  return response(
+    {
+      ok: true,
+      streams: successValue(maybeStreams),
+      // The UI builds its demo dropdown from this, so the two cannot drift.
+      demos: Object.keys(demos),
+    },
+    200,
+    {
+      'Cache-Control': 'no-cache',
+    },
+  );
+});

--- a/backend-lambda/src/handlers/adminUpdateStream.ts
+++ b/backend-lambda/src/handlers/adminUpdateStream.ts
@@ -1,0 +1,95 @@
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { catchErrors } from '../helpers/catchErrors';
+import { accessDenied, invalidRequest, notFound, response } from '../helpers/response';
+import { isFailure, successValue } from '../helpers/result';
+import { parseBody } from '../helpers/parseBody';
+import { requireRole } from '../helpers/requireRole';
+import { ssm } from '../helpers/ssm';
+import { TableName } from '../helpers/TableName';
+import { isAdminTagEditRequest } from '../types.guard';
+import { demos } from './mux/demos';
+import { applyTagEdits, isMissingParameterError } from './admin/applyTagEdits';
+import { parseTagEdits } from './admin/parseTagEdits';
+import { readRoomTags } from './admin/readRoomTags';
+import { refreshAfterEdit } from './admin/refreshAfterEdit';
+
+export const adminUpdateStream: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
+  if (!TableName) {
+    throw new Error('CACHE_TABLE_NAME not set');
+  }
+
+  if (!(await requireRole(event))) {
+    return accessDenied();
+  }
+
+  const roomId = event.pathParameters?.muxTokenId;
+  if (roomId === undefined || roomId.length === 0) {
+    return notFound();
+  }
+
+  const maybeBody = parseBody(event.body, isAdminTagEditRequest);
+  if (isFailure(maybeBody)) {
+    return invalidRequest('Body must be a tag edit request');
+  }
+
+  const maybePlan = parseTagEdits(successValue(maybeBody), Object.keys(demos));
+  if (isFailure(maybePlan)) {
+    return invalidRequest(maybePlan.value.message);
+  }
+
+  const plan = successValue(maybePlan);
+
+  // Read first, for two reasons: it turns a bad roomId into a 404 rather than a
+  // 500, and it lets us drop removals for tags that are not set. Whether SSM
+  // treats removing an absent tag key as a no-op is undocumented, and clearing
+  // the title of a never-titled stream would send exactly that.
+  const maybeCurrentTags = await readRoomTags(ssm, roomId);
+  if (isFailure(maybeCurrentTags)) {
+    if (isMissingParameterError(maybeCurrentTags.value)) {
+      console.log(`No parameter for ${roomId}`);
+      return notFound();
+    }
+    throw maybeCurrentTags.value;
+  }
+
+  const currentTags = successValue(maybeCurrentTags);
+
+  const maybeApplied = await applyTagEdits(ssm, roomId, {
+    set: plan.set,
+    remove: plan.remove.filter((key) => currentTags[key] !== undefined),
+  });
+
+  if (isFailure(maybeApplied)) {
+    if (isMissingParameterError(maybeApplied.value)) {
+      console.log(`No parameter for ${roomId}`);
+      return notFound();
+    }
+    throw maybeApplied.value;
+  }
+
+  // The tags are already committed. A refresh failure must not be reported as a
+  // failed save: getStreamStateFromDynamo reaches Mux, so clearing multiview:demo
+  // on a stream that is not currently live fails here for a save that landed
+  // correctly. Report it separately and let the 60s TTL catch up.
+  const maybeRefreshed = await refreshAfterEdit(TableName, roomId);
+  if (isFailure(maybeRefreshed)) {
+    console.log(`Tags written for ${roomId} but the refresh failed`, maybeRefreshed.value);
+  }
+
+  const maybeTags = await readRoomTags(ssm, roomId);
+  if (isFailure(maybeTags)) {
+    throw maybeTags.value;
+  }
+
+  return response(
+    {
+      ok: true,
+      refreshed: !isFailure(maybeRefreshed),
+      stream: { id: roomId, tags: successValue(maybeTags) },
+    },
+    200,
+    {
+      'Cache-Control': 'no-cache',
+    },
+  );
+});

--- a/backend-lambda/src/handlers/devtoken.ts
+++ b/backend-lambda/src/handlers/devtoken.ts
@@ -2,36 +2,16 @@ import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { TableName } from '../helpers/TableName';
 import { catchErrors } from '../helpers/catchErrors';
 import { accessDenied, response } from '../helpers/response';
-import { verifyTokenCookie } from '../helpers/verifyTokenCookie';
-import { JWTRequiredRole } from '../helpers/env/ATTEND_JWT_REQUIRED_ROLE';
+import { requireRole } from '../helpers/requireRole';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const devtoken: APIGatewayProxyHandlerV2 = catchErrors(async (event, context) => {
+export const devtoken: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
   if (!TableName) {
     throw new Error('CACHE_TABLE_NAME not set');
   }
 
-  const maybeToken = await verifyTokenCookie(event, true);
+  const maybeToken = await requireRole(event);
 
   if (!maybeToken) {
-    return accessDenied();
-  }
-
-  const requiredRoles = (JWTRequiredRole ?? '')
-    .split(',')
-    .map((role) => role.trim())
-    .filter((role) => role.length > 0);
-
-  if (requiredRoles.length == 0) {
-    return accessDenied();
-  }
-
-  const hasRequiredRole = requiredRoles.some((role) => role === maybeToken.token.role);
-  if (!hasRequiredRole) {
-    console.log(
-      `(requestId=${event.requestContext.requestId}) Access denied because the token does not have any of ${requiredRoles.join(',')}.`,
-    );
-
     return accessDenied();
   }
 

--- a/backend-lambda/src/helpers/requireRole.ts
+++ b/backend-lambda/src/helpers/requireRole.ts
@@ -1,0 +1,38 @@
+import { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { verifyTokenCookie } from './verifyTokenCookie';
+import { JWTRequiredRole } from './env/ATTEND_JWT_REQUIRED_ROLE';
+
+/**
+ * Verifies the NDV_AUD cookie and checks the token carries one of the roles in
+ * ATTEND_JWT_REQUIRED_ROLE. Returns undefined when the caller should be denied.
+ */
+export const requireRole = async (event: APIGatewayProxyEventV2) => {
+  const maybeToken = await verifyTokenCookie(event, true);
+
+  if (!maybeToken) {
+    return undefined;
+  }
+
+  const requiredRoles = (JWTRequiredRole ?? '')
+    .split(',')
+    .map((role) => role.trim())
+    .filter((role) => role.length > 0);
+
+  if (requiredRoles.length == 0) {
+    console.log(
+      `(requestId=${event.requestContext.requestId}) Access denied because ATTEND_JWT_REQUIRED_ROLE is not set.`,
+    );
+    return undefined;
+  }
+
+  const hasRequiredRole = requiredRoles.some((role) => role === maybeToken.token.role);
+  if (!hasRequiredRole) {
+    console.log(
+      `(requestId=${event.requestContext.requestId}) Access denied because the token does not have any of ${requiredRoles.join(',')}.`,
+    );
+
+    return undefined;
+  }
+
+  return maybeToken;
+};

--- a/backend-lambda/src/index.ts
+++ b/backend-lambda/src/index.ts
@@ -5,3 +5,4 @@ export { muxWebhook } from './handlers/muxWebhook';
 export { ablyKey } from './handlers/ablyKey';
 export { attend } from './handlers/attend';
 export { devtoken } from './handlers/devtoken';
+export { adminListStreams } from './handlers/adminListStreams';

--- a/backend-lambda/src/index.ts
+++ b/backend-lambda/src/index.ts
@@ -6,3 +6,4 @@ export { ablyKey } from './handlers/ablyKey';
 export { attend } from './handlers/attend';
 export { devtoken } from './handlers/devtoken';
 export { adminListStreams } from './handlers/adminListStreams';
+export { adminUpdateStream } from './handlers/adminUpdateStream';

--- a/backend-lambda/src/types.ts
+++ b/backend-lambda/src/types.ts
@@ -10,3 +10,11 @@ export interface DecodedJWT {
   sub: string;
   role: string;
 }
+
+/** @see {isAdminTagEditRequest} ts-auto-guard:type-guard */
+export interface AdminTagEditRequest {
+  title?: string;
+  order?: string | number;
+  show?: boolean;
+  demo?: string | null;
+}

--- a/backend-lambda/tsconfig.json
+++ b/backend-lambda/tsconfig.json
@@ -12,6 +12,7 @@
       "src/**/*.ts"
   ],
   "exclude": [
-      "node_modules"
+      "node_modules",
+      "**/*.test.ts"
   ]
 }

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -636,6 +636,7 @@ git commit -m "feat: add GET /admin/streams"
 
 **Files:**
 - Create: `backend-lambda/src/handlers/admin/applyTagEdits.ts`
+- Create: `backend-lambda/src/handlers/admin/readRoomTags.ts`
 - Create: `backend-lambda/src/handlers/admin/refreshAfterEdit.ts`
 - Create: `backend-lambda/src/handlers/adminUpdateStream.ts`
 - Modify: `backend-lambda/src/index.ts`
@@ -658,7 +659,16 @@ grep -rn "InvalidResourceId" node_modules/@aws-sdk/client-ssm/dist-types/models/
 
 Expected: a hit for an `InvalidResourceId` exception class. The AWS SDK sets `err.name` to the exception's shape name. If the grep finds nothing, list the exceptions the operation declares and use the correct name in Step 2 instead of `InvalidResourceId`. Do not use `ParameterNotFound` — that belongs to the `GetParameter` family, not the tagging APIs.
 
-Also confirm that `removeTagsFromResource` is a no-op when a listed `TagKeys` entry is not present on the parameter. This matters because clearing a title on a stream that never had a `multiview:title` tag sends exactly that. AWS tag-removal APIs are normally idempotent, so no-op is the expected answer. If it turns out to raise instead, change `adminUpdateStream` (Step 4) to call `getRoomWithTags` *before* `applyTagEdits` and filter `plan.remove` down to keys that are actually present — do not silently swallow the error.
+**Outcome when this plan was executed:** `InvalidResourceId` is declared for `AddTagsToResource`,
+`RemoveTagsFromResource` and `ListTagsForResource`. `ParameterNotFound` is not. The constant is correct.
+
+Whether `removeTagsFromResource` is a no-op for a `TagKeys` entry that is not present on the
+parameter is **not** answerable from the SDK types, and this repo cannot call AWS. Rather than ship
+an unverifiable assumption, the fallback described here was taken as the default: `adminUpdateStream`
+reads the current tags *before* `applyTagEdits` and filters `plan.remove` to keys that exist. That
+also turns an unknown `muxTokenId` into a 404 instead of a 500, because `getRoomWithTags` throws
+rather than returning a failure when the parameter is missing. The extra read is one
+`ListTagsForResource` call per save.
 
 - [ ] **Step 2: Implement the tag write**
 

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -1,0 +1,1294 @@
+# Stream Admin UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a role-gated web page that lets an event operator edit the `multiview:*` SSM tags on existing `/multiview/mux/*` parameters, refreshing every affected cache after each edit.
+
+**Architecture:** Two new Lambda handlers behind API Gateway — `GET /admin/streams` reads all parameters and their tags straight from SSM (unfiltered, so hidden rooms remain editable), and `POST /admin/streams/{muxTokenId}` validates a tag edit, writes it via SSM tagging APIs, then force-refreshes the rooms cache, that room's stream cache, and publishes to Ably. A single-page Parcel entry point (`admin.html`) renders one editable row per stream and saves rows independently.
+
+**Tech Stack:** TypeScript, AWS SDK v3 (`@aws-sdk/client-ssm`, `@aws-sdk/client-dynamodb`), aws-lambda, jest + ts-jest (backend), Parcel + Tailwind v4 (frontend), CloudFormation.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md`
+
+## Global Constraints
+
+- `backend-lambda` is `strict: true`. `frontend` is `strict: false`. Do not assume frontend patterns typecheck in the backend.
+- Errors are values. Use `helpers/result.ts` (`Result`/`success`/`failure`/`isFailure`/`successValue`). Do not throw for expected failures. Handlers wrap in `catchErrors` and return via `helpers/response.ts`.
+- `backend-lambda/src/types.guard.ts` is **generated**. Edit `types.ts`, then run `./node_modules/.bin/ts-auto-guard --debug`. Never hand-edit the guard file.
+- `pnpm run <script>` hangs in a network-restricted sandbox. Always call binaries directly: `./node_modules/.bin/tsc`, `./node_modules/.bin/jest`, `./node_modules/.bin/ts-auto-guard`, `./node_modules/.bin/prettier`.
+- `pnpm lint` is broken in both projects (eslint 10 vs legacy `.eslintrc.js`). Do not try to fix it here. `./node_modules/.bin/prettier --check ./src/` works and is the formatting gate.
+- Tag keys, exact strings: `multiview:title`, `multiview:order`, `multiview:show`, `multiview:demo`. Note `multiview`, not `multview`.
+- `multiview:show` must be written as the literal string `"true"` or `"false"` — the read path at `getRoomsFromSSM.ts:44` is a string comparison.
+- The SSM path prefix is `/multiview/mux/` and the region is `us-east-1`.
+- The Ably channel name is exactly `mux-monitor.aws.nextdayvideo.com.au`.
+- Never return an SSM parameter *value* to a client. Values under `/multiview/mux/` are Mux token secrets.
+- Do not add routes to the monitor CloudFront distribution. It is deliberately unauthenticated (on-site event use); only the attendee distribution forwards cookies.
+- Commit after every task.
+
+## File Structure
+
+**Backend — create:**
+
+| File | Responsibility |
+|---|---|
+| `backend-lambda/src/helpers/requireRole.ts` | Cookie verification + role check, shared by devtoken and both admin handlers |
+| `backend-lambda/src/handlers/admin/AdminStream.ts` | Tag key constants and the `AdminStream` / `TagEditPlan` types |
+| `backend-lambda/src/handlers/admin/parseTagEdits.ts` | Pure: request → validated add/remove plan |
+| `backend-lambda/src/handlers/admin/parseTagEdits.test.ts` | Unit tests for the above |
+| `backend-lambda/src/handlers/admin/listStreamsFromSSM.ts` | Paginated, unfiltered listing with tags |
+| `backend-lambda/src/handlers/admin/applyTagEdits.ts` | Executes the plan via SSM tagging APIs |
+| `backend-lambda/src/handlers/admin/refreshAfterEdit.ts` | Rooms cache + stream cache + Ably publish |
+| `backend-lambda/src/handlers/adminListStreams.ts` | `GET /admin/streams` |
+| `backend-lambda/src/handlers/adminUpdateStream.ts` | `POST /admin/streams/{muxTokenId}` |
+| `backend-lambda/jest.config.js` | ts-jest harness |
+
+**Backend — modify:** `src/index.ts`, `src/types.ts`, `src/types.guard.ts` (regenerated), `src/handlers/devtoken.ts`, `package.json`, `tsconfig.json`.
+
+**Frontend — create:** `src/admin.html`, `src/js/admin.ts`, `src/js/admin/fetchStreams.ts`, `src/js/admin/saveStream.ts`.
+
+**Infra — modify:** `infra/main-stack/deployment.cfn.yaml`.
+
+---
+
+### Task 1: Shared role helper
+
+Extract the role check from `devtoken.ts` so all three protected endpoints share one implementation. Pure refactor — behaviour must not change.
+
+**Files:**
+- Create: `backend-lambda/src/helpers/requireRole.ts`
+- Modify: `backend-lambda/src/handlers/devtoken.ts`
+
+**Interfaces:**
+- Consumes: `verifyTokenCookie` from `helpers/verifyTokenCookie.ts`, `JWTRequiredRole` from `helpers/env/ATTEND_JWT_REQUIRED_ROLE.ts`.
+- Produces: `requireRole(event: APIGatewayProxyEventV2): Promise<{ cookie: string; token: DecodedJWT } | undefined>` — used by Tasks 3 and 4.
+
+- [ ] **Step 1: Create the helper**
+
+Create `backend-lambda/src/helpers/requireRole.ts`:
+
+```typescript
+import { APIGatewayProxyEventV2 } from 'aws-lambda';
+import { verifyTokenCookie } from './verifyTokenCookie';
+import { JWTRequiredRole } from './env/ATTEND_JWT_REQUIRED_ROLE';
+
+/**
+ * Verifies the NDV_AUD cookie and checks the token carries one of the roles in
+ * ATTEND_JWT_REQUIRED_ROLE. Returns undefined when the caller should be denied.
+ */
+export const requireRole = async (event: APIGatewayProxyEventV2) => {
+  const maybeToken = await verifyTokenCookie(event, true);
+
+  if (!maybeToken) {
+    return undefined;
+  }
+
+  const requiredRoles = (JWTRequiredRole ?? '')
+    .split(',')
+    .map((role) => role.trim())
+    .filter((role) => role.length > 0);
+
+  if (requiredRoles.length == 0) {
+    console.log(
+      `(requestId=${event.requestContext.requestId}) Access denied because ATTEND_JWT_REQUIRED_ROLE is not set.`,
+    );
+    return undefined;
+  }
+
+  const hasRequiredRole = requiredRoles.some((role) => role === maybeToken.token.role);
+  if (!hasRequiredRole) {
+    console.log(
+      `(requestId=${event.requestContext.requestId}) Access denied because the token does not have any of ${requiredRoles.join(',')}.`,
+    );
+
+    return undefined;
+  }
+
+  return maybeToken;
+};
+```
+
+- [ ] **Step 2: Rewrite devtoken to use it**
+
+Replace the entire contents of `backend-lambda/src/handlers/devtoken.ts`:
+
+```typescript
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { TableName } from '../helpers/TableName';
+import { catchErrors } from '../helpers/catchErrors';
+import { accessDenied, response } from '../helpers/response';
+import { requireRole } from '../helpers/requireRole';
+
+export const devtoken: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
+  if (!TableName) {
+    throw new Error('CACHE_TABLE_NAME not set');
+  }
+
+  const maybeToken = await requireRole(event);
+
+  if (!maybeToken) {
+    return accessDenied();
+  }
+
+  return response(
+    {
+      ok: true,
+      cookie: maybeToken.cookie,
+    },
+    200,
+    {
+      'Cache-Control': 'no-cache',
+    },
+  );
+});
+```
+
+Note the handler now takes only `event`. `catchErrors` accepts a two-parameter function, and a one-parameter function is assignable to it, so the `eslint-disable` comment for the unused `context` is no longer needed.
+
+- [ ] **Step 3: Typecheck**
+
+Run from `backend-lambda/`: `./node_modules/.bin/tsc --noEmit`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend-lambda/src/helpers/requireRole.ts backend-lambda/src/handlers/devtoken.ts
+git commit -m "refactor: extract requireRole helper from devtoken"
+```
+
+---
+
+### Task 2: Tag edit validation (with jest harness)
+
+The pure core of the feature. Sets up the jest harness because this is the first test in `backend-lambda`.
+
+**Files:**
+- Create: `backend-lambda/jest.config.js`
+- Create: `backend-lambda/src/handlers/admin/AdminStream.ts`
+- Create: `backend-lambda/src/handlers/admin/parseTagEdits.ts`
+- Test: `backend-lambda/src/handlers/admin/parseTagEdits.test.ts`
+- Modify: `backend-lambda/package.json`, `backend-lambda/tsconfig.json`
+
+**Interfaces:**
+- Consumes: `Result`/`success`/`failure` from `helpers/result.ts`.
+- Produces:
+  - `TAG_TITLE`, `TAG_ORDER`, `TAG_SHOW`, `TAG_DEMO` string constants
+  - `type AdminTags = Record<string, string>`
+  - `interface AdminStream { id: string; tags: AdminTags }`
+  - `interface TagEditPlan { set: AdminTags; remove: string[] }`
+  - `parseTagEdits(request: AdminTagEditRequest, validDemos: string[]): Result<Error, TagEditPlan>`
+
+  Tasks 3, 4 and 6 depend on these exact names.
+
+- [ ] **Step 1: Set up the jest harness**
+
+`jest`, `@types/jest` and `ts-jest` are already devDependencies — no installs needed.
+
+Create `backend-lambda/jest.config.js`:
+
+```javascript
+module.exports = {
+  testEnvironment: 'node',
+  preset: 'ts-jest',
+  testMatch: ['**/*.test.ts'],
+};
+```
+
+Add a `test` script to `backend-lambda/package.json`, immediately after the `"watch"` line:
+
+```json
+    "test": "jest",
+```
+
+In `backend-lambda/tsconfig.json`, change the `exclude` array so test files are never emitted into `dist/` (and therefore never shipped inside `build.zip`):
+
+```json
+  "exclude": [
+      "node_modules",
+      "**/*.test.ts"
+  ]
+```
+
+- [ ] **Step 2: Create the shared types**
+
+Create `backend-lambda/src/handlers/admin/AdminStream.ts`:
+
+```typescript
+export const TAG_TITLE = 'multiview:title';
+export const TAG_ORDER = 'multiview:order';
+export const TAG_SHOW = 'multiview:show';
+export const TAG_DEMO = 'multiview:demo';
+
+export type AdminTags = Record<string, string>;
+
+/** One SSM parameter under /multiview/mux/. Never carries the parameter value. */
+export interface AdminStream {
+  id: string;
+  tags: AdminTags;
+}
+
+/** Tags to write, and tag keys to delete. */
+export interface TagEditPlan {
+  set: AdminTags;
+  remove: string[];
+}
+```
+
+- [ ] **Step 3: Add the request type and regenerate the guard**
+
+Append to `backend-lambda/src/types.ts`:
+
+```typescript
+/** @see {isAdminTagEditRequest} ts-auto-guard:type-guard */
+export interface AdminTagEditRequest {
+  title?: string;
+  order?: string | number;
+  show?: boolean;
+  demo?: string | null;
+}
+```
+
+Regenerate from `backend-lambda/`: `./node_modules/.bin/ts-auto-guard --debug`
+
+Confirm `src/types.guard.ts` now exports `isAdminTagEditRequest`. Do not hand-edit that file.
+
+- [ ] **Step 4: Write the failing tests**
+
+Create `backend-lambda/src/handlers/admin/parseTagEdits.test.ts`:
+
+```typescript
+import { isFailure, isSuccess, successValue } from '../../helpers/result';
+import { TAG_DEMO, TAG_ORDER, TAG_SHOW, TAG_TITLE } from './AdminStream';
+import { parseTagEdits } from './parseTagEdits';
+
+const demos = ['offline', 'fake-stream'];
+
+const planFor = (request: Parameters<typeof parseTagEdits>[0]) => {
+  const result = parseTagEdits(request, demos);
+  if (!isSuccess(result)) {
+    throw new Error(`Expected success, got failure: ${result.value.message}`);
+  }
+  return successValue(result);
+};
+
+describe('parseTagEdits', () => {
+  it('returns an empty plan for an empty request', () => {
+    expect(planFor({})).toEqual({ set: {}, remove: [] });
+  });
+
+  it('writes order from a number', () => {
+    expect(planFor({ order: 5 }).set[TAG_ORDER]).toBe('5');
+  });
+
+  it('writes order from a numeric string', () => {
+    expect(planFor({ order: '5' }).set[TAG_ORDER]).toBe('5');
+  });
+
+  it('accepts a negative order', () => {
+    expect(planFor({ order: '-2' }).set[TAG_ORDER]).toBe('-2');
+  });
+
+  it('rejects a partially numeric order rather than truncating it', () => {
+    expect(isFailure(parseTagEdits({ order: '12abc' }, demos))).toBe(true);
+  });
+
+  it('rejects a non-integer order', () => {
+    expect(isFailure(parseTagEdits({ order: 1.5 }, demos))).toBe(true);
+  });
+
+  it('rejects an empty order', () => {
+    expect(isFailure(parseTagEdits({ order: '' }, demos))).toBe(true);
+  });
+
+  it('writes show as the literal string true', () => {
+    expect(planFor({ show: true }).set[TAG_SHOW]).toBe('true');
+  });
+
+  it('writes show as the literal string false', () => {
+    expect(planFor({ show: false }).set[TAG_SHOW]).toBe('false');
+  });
+
+  it('trims the title', () => {
+    expect(planFor({ title: '  Room One  ' }).set[TAG_TITLE]).toBe('Room One');
+  });
+
+  it('removes the title tag when the title is blank', () => {
+    const plan = planFor({ title: '   ' });
+    expect(plan.remove).toContain(TAG_TITLE);
+    expect(plan.set[TAG_TITLE]).toBeUndefined();
+  });
+
+  it('accepts a known demo', () => {
+    expect(planFor({ demo: 'fake-stream' }).set[TAG_DEMO]).toBe('fake-stream');
+  });
+
+  it('rejects an unknown demo', () => {
+    expect(isFailure(parseTagEdits({ demo: 'nope' }, demos))).toBe(true);
+  });
+
+  it('removes the demo tag when demo is null', () => {
+    const plan = planFor({ demo: null });
+    expect(plan.remove).toContain(TAG_DEMO);
+    expect(plan.set[TAG_DEMO]).toBeUndefined();
+  });
+
+  it('handles a full edit in one plan', () => {
+    const plan = planFor({ title: 'Main Hall', order: 1, show: true, demo: null });
+    expect(plan.set).toEqual({
+      [TAG_TITLE]: 'Main Hall',
+      [TAG_ORDER]: '1',
+      [TAG_SHOW]: 'true',
+    });
+    expect(plan.remove).toEqual([TAG_DEMO]);
+  });
+});
+```
+
+- [ ] **Step 5: Run the tests to verify they fail**
+
+Run from `backend-lambda/`: `./node_modules/.bin/jest`
+Expected: FAIL — cannot resolve `./parseTagEdits`.
+
+- [ ] **Step 6: Implement**
+
+Create `backend-lambda/src/handlers/admin/parseTagEdits.ts`:
+
+```typescript
+import { failure, Result, success } from '../../helpers/result';
+import { AdminTagEditRequest } from '../../types';
+import { TAG_DEMO, TAG_ORDER, TAG_SHOW, TAG_TITLE, TagEditPlan } from './AdminStream';
+
+const INTEGER = /^-?\d+$/;
+
+/**
+ * Validates a tag edit request and turns it into tags to write and tag keys to
+ * delete. Pure: does no IO. `validDemos` comes from handlers/mux/demos.ts so the
+ * accepted values cannot drift from the ones the player understands.
+ */
+export const parseTagEdits = (request: AdminTagEditRequest, validDemos: string[]): Result<Error, TagEditPlan> => {
+  const set: Record<string, string> = {};
+  const remove: string[] = [];
+
+  if (request.title !== undefined) {
+    const title = request.title.trim();
+    if (title.length === 0) {
+      // getRoomWithTags discards falsy tag values, so an empty title is a removal.
+      remove.push(TAG_TITLE);
+    } else {
+      set[TAG_TITLE] = title;
+    }
+  }
+
+  if (request.order !== undefined) {
+    if (typeof request.order === 'number') {
+      if (!Number.isInteger(request.order)) {
+        return failure(new Error('order must be a whole number'));
+      }
+      set[TAG_ORDER] = String(request.order);
+    } else {
+      // parseInt('12abc') is 12, so test the whole string before converting.
+      if (!INTEGER.test(request.order.trim())) {
+        return failure(new Error('order must be a whole number'));
+      }
+      set[TAG_ORDER] = String(parseInt(request.order.trim(), 10));
+    }
+  }
+
+  if (request.show !== undefined) {
+    set[TAG_SHOW] = request.show ? 'true' : 'false';
+  }
+
+  if (request.demo !== undefined) {
+    if (request.demo === null) {
+      remove.push(TAG_DEMO);
+    } else if (!validDemos.includes(request.demo)) {
+      return failure(new Error(`demo must be one of ${validDemos.join(', ')}`));
+    } else {
+      set[TAG_DEMO] = request.demo;
+    }
+  }
+
+  return success({ set, remove });
+};
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run from `backend-lambda/`: `./node_modules/.bin/jest`
+Expected: PASS, 15 tests.
+
+Then `./node_modules/.bin/tsc --noEmit` — expected: no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend-lambda/jest.config.js backend-lambda/package.json backend-lambda/tsconfig.json \
+        backend-lambda/src/types.ts backend-lambda/src/types.guard.ts \
+        backend-lambda/src/handlers/admin/
+git commit -m "feat: add tag edit validation and a jest harness for backend-lambda"
+```
+
+---
+
+### Task 3: List streams endpoint
+
+**Files:**
+- Create: `backend-lambda/src/handlers/admin/listStreamsFromSSM.ts`
+- Create: `backend-lambda/src/handlers/adminListStreams.ts`
+- Modify: `backend-lambda/src/index.ts`
+
+**Interfaces:**
+- Consumes: `AdminStream`, `AdminTags`, `TAG_ORDER` (Task 2); `requireRole` (Task 1); `getRoomWithTags` from `handlers/rooms/getRoomWithTags.ts`; `getOrderFromTag` from `handlers/rooms/getOrderFromTag.ts`; `demos` from `handlers/mux/demos.ts`.
+- Produces: `listStreamsFromSSM(): Promise<Result<Error, AdminStream[]>>`; the `adminListStreams` handler export.
+
+- [ ] **Step 1: Implement the listing**
+
+Create `backend-lambda/src/handlers/admin/listStreamsFromSSM.ts`:
+
+```typescript
+import PQueue from '@esm2cjs/p-queue';
+import { notUndefined } from '../../helpers/notUndefined';
+import { failure, isFailure, isSuccess, Result, success, successValue } from '../../helpers/result';
+import { ssm } from '../../helpers/ssm';
+import { getOrderFromTag } from '../rooms/getOrderFromTag';
+import { getRoomWithTags, RoomWithTags } from '../rooms/getRoomWithTags';
+import { AdminStream, AdminTags, TAG_ORDER } from './AdminStream';
+
+const path = '/multiview/mux/';
+
+const tagsQueue = new PQueue({ concurrency: 4 });
+
+const orderOf = (tags: AdminTags): number => getOrderFromTag(tags[TAG_ORDER], Number.MAX_SAFE_INTEGER);
+
+/**
+ * Every parameter under /multiview/mux/ with its tags, unfiltered — unlike
+ * getRoomsFromSSM, which drops anything without multiview:show=true. The admin UI
+ * must be able to see (and un-hide) hidden rooms.
+ *
+ * Only Name is read from the response. The parameter values are Mux token secrets
+ * and must never reach a client.
+ */
+export const listStreamsFromSSM = async (): Promise<Result<Error, AdminStream[]>> => {
+  const names: string[] = [];
+  let nextToken: string | undefined = undefined;
+
+  // getParametersByPath returns 10 per page by default. getRoomsFromSSM does not
+  // paginate; an admin list that silently truncates would be a bad failure mode.
+  do {
+    const page = await ssm.getParametersByPath({ Path: path, NextToken: nextToken });
+
+    if (page.Parameters == null) {
+      return failure(new Error('Unexpected AWS response'));
+    }
+
+    names.push(...page.Parameters.map(({ Name }) => Name).filter(notUndefined));
+
+    nextToken = page.NextToken;
+  } while (nextToken !== undefined);
+
+  // PQueue.add resolves to `Result | void`, so the null check is not optional —
+  // this mirrors getRoomsFromSSM.ts:26-31 rather than using `??`, which does not
+  // narrow a `void` union cleanly under strict.
+  const settled = await Promise.all(names.map((name) => tagsQueue.add(() => getRoomWithTags(ssm, name))));
+
+  const maybeStreams = settled.map((r) => {
+    if (r == null) {
+      return failure<Error, RoomWithTags>(new Error('Cancelled'));
+    }
+    return r;
+  });
+
+  const errors = maybeStreams.filter(isFailure).map(({ value }) => value);
+
+  if (errors.length > 0) {
+    return failure(new Error(`${errors.length} errors fetching tags. ${errors.map((e) => e.message).join(', ')}`));
+  }
+
+  const streams = maybeStreams
+    .filter(isSuccess)
+    .map(successValue)
+    .map(({ id, tags }) => ({ id: id.substring(path.length), tags }))
+    .sort((first, second) => orderOf(first.tags) - orderOf(second.tags) || first.id.localeCompare(second.id));
+
+  return success(streams);
+};
+```
+
+- [ ] **Step 2: Implement the handler**
+
+Create `backend-lambda/src/handlers/adminListStreams.ts`:
+
+```typescript
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { catchErrors } from '../helpers/catchErrors';
+import { accessDenied, response } from '../helpers/response';
+import { isFailure, successValue } from '../helpers/result';
+import { requireRole } from '../helpers/requireRole';
+import { demos } from './mux/demos';
+import { listStreamsFromSSM } from './admin/listStreamsFromSSM';
+
+export const adminListStreams: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
+  if (!(await requireRole(event))) {
+    return accessDenied();
+  }
+
+  const maybeStreams = await listStreamsFromSSM();
+
+  if (isFailure(maybeStreams)) {
+    throw maybeStreams.value;
+  }
+
+  return response(
+    {
+      ok: true,
+      streams: successValue(maybeStreams),
+      // The UI builds its demo dropdown from this, so the two cannot drift.
+      demos: Object.keys(demos),
+    },
+    200,
+    {
+      'Cache-Control': 'no-cache',
+    },
+  );
+});
+```
+
+- [ ] **Step 3: Export it**
+
+Add to `backend-lambda/src/index.ts`, after the `devtoken` line:
+
+```typescript
+export { adminListStreams } from './handlers/adminListStreams';
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run from `backend-lambda/`: `./node_modules/.bin/tsc --noEmit`
+Expected: no output.
+
+If `nextToken` produces an implicit-any or type-widening error under `strict`, keep the explicit `let nextToken: string | undefined = undefined;` annotation shown above — do not switch to `while (true)` with a `break`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend-lambda/src/handlers/admin/listStreamsFromSSM.ts \
+        backend-lambda/src/handlers/adminListStreams.ts backend-lambda/src/index.ts
+git commit -m "feat: add GET /admin/streams"
+```
+
+---
+
+### Task 4: Update stream endpoint
+
+**Files:**
+- Create: `backend-lambda/src/handlers/admin/applyTagEdits.ts`
+- Create: `backend-lambda/src/handlers/admin/refreshAfterEdit.ts`
+- Create: `backend-lambda/src/handlers/adminUpdateStream.ts`
+- Modify: `backend-lambda/src/index.ts`
+
+**Interfaces:**
+- Consumes: `TagEditPlan`, `AdminTags`, `parseTagEdits` (Task 2); `requireRole` (Task 1); `isAdminTagEditRequest` from `types.guard.ts`; `getRoomsFromDynamo`, `getStreamStateFromDynamo`, `getAblyClient`, `getRoomWithTags`, `parseBody`, `TableName`.
+- Produces:
+  - `applyTagEdits(ssm: SSM, roomId: string, plan: TagEditPlan): Promise<Result<Error, void>>`
+  - `isMissingParameterError(err: Error): boolean`
+  - `refreshAfterEdit(tableName: string, roomId: string): Promise<Result<Error, StreamStateWithTitle>>`
+  - the `adminUpdateStream` handler export
+
+- [ ] **Step 1: Confirm the SSM not-found error name**
+
+Before writing the code, confirm what `addTagsToResource` throws for a parameter that does not exist. Run from `backend-lambda/`:
+
+```bash
+grep -rn "InvalidResourceId" node_modules/@aws-sdk/client-ssm/dist-types/models/ | head
+```
+
+Expected: a hit for an `InvalidResourceId` exception class. The AWS SDK sets `err.name` to the exception's shape name. If the grep finds nothing, list the exceptions the operation declares and use the correct name in Step 2 instead of `InvalidResourceId`. Do not use `ParameterNotFound` — that belongs to the `GetParameter` family, not the tagging APIs.
+
+- [ ] **Step 2: Implement the tag write**
+
+Create `backend-lambda/src/handlers/admin/applyTagEdits.ts`:
+
+```typescript
+import { SSM } from '@aws-sdk/client-ssm';
+import { failure, Result, success } from '../../helpers/result';
+import { TagEditPlan } from './AdminStream';
+
+/**
+ * SSM raises InvalidResourceId when the tag target does not exist. That is the
+ * only signal we get that the roomId is wrong, since we do no separate existence
+ * check (which would leave a time-of-check/time-of-use gap anyway).
+ */
+export const isMissingParameterError = (err: Error): boolean => err.name === 'InvalidResourceId';
+
+/**
+ * Applies a plan with up to two SSM calls. Clearing a tag is a RemoveTagsFromResource
+ * call, not an AddTagsToResource with an empty value.
+ */
+export const applyTagEdits = async (ssm: SSM, roomId: string, plan: TagEditPlan): Promise<Result<Error, void>> => {
+  const ResourceId = `/multiview/mux/${roomId}`;
+
+  const tags = Object.entries(plan.set).map(([Key, Value]) => ({ Key, Value }));
+
+  try {
+    if (tags.length > 0) {
+      await ssm.addTagsToResource({ ResourceType: 'Parameter', ResourceId, Tags: tags });
+    }
+
+    if (plan.remove.length > 0) {
+      await ssm.removeTagsFromResource({ ResourceType: 'Parameter', ResourceId, TagKeys: plan.remove });
+    }
+  } catch (err) {
+    return failure(err as Error);
+  }
+
+  return success(undefined);
+};
+```
+
+- [ ] **Step 3: Implement the refresh**
+
+Create `backend-lambda/src/handlers/admin/refreshAfterEdit.ts`:
+
+```typescript
+import { isFailure, Result, success, successValue } from '../../helpers/result';
+import { getRoomsFromDynamo } from '../rooms/getRoomsFromDynamo';
+import { getStreamStateFromDynamo } from '../mux/getStreamStateFromDynamo';
+import { getAblyClient } from '../ably/getAblyClient';
+import { StreamStateWithTitle } from '../mux/StreamState';
+
+const CHANNEL = 'mux-monitor.aws.nextdayvideo.com.au';
+
+/**
+ * A tag edit can change both caches: multiview:show and multiview:order feed
+ * rooms/all, while multiview:title and multiview:demo feed stream/<roomId>.
+ * /api/refresh only does the former, so both are forced here.
+ *
+ * The Ably publish is best-effort. By the time it runs the tags are written and
+ * both caches are correct, so a publish failure must not be reported as a failed
+ * save.
+ */
+export const refreshAfterEdit = async (
+  tableName: string,
+  roomId: string,
+): Promise<Result<Error, StreamStateWithTitle>> => {
+  const maybeAblyTask = getAblyClient();
+
+  const maybeRooms = await getRoomsFromDynamo(tableName, true);
+  if (isFailure(maybeRooms)) {
+    return maybeRooms;
+  }
+
+  const maybeState = await getStreamStateFromDynamo(tableName, roomId, true);
+  if (isFailure(maybeState)) {
+    return maybeState;
+  }
+
+  const state = successValue(maybeState);
+
+  const maybeAbly = await maybeAblyTask;
+
+  if (isFailure(maybeAbly)) {
+    console.log('Failed to initialise ably', maybeAbly.value);
+  } else {
+    const ably = successValue(maybeAbly);
+
+    if (ably == undefined) {
+      console.log('Not notifying ably (ABLY_SERVER_KEY not set)');
+    } else {
+      try {
+        await ably.channels.get(CHANNEL).publish('stream', { roomId, why: 'admin-edit', ...state });
+      } catch (err) {
+        console.log('Failed to publish to ably', err);
+      }
+    }
+  }
+
+  return success(state);
+};
+```
+
+- [ ] **Step 4: Implement the handler**
+
+Create `backend-lambda/src/handlers/adminUpdateStream.ts`:
+
+```typescript
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import { catchErrors } from '../helpers/catchErrors';
+import { accessDenied, invalidRequest, notFound, response } from '../helpers/response';
+import { isFailure, successValue } from '../helpers/result';
+import { parseBody } from '../helpers/parseBody';
+import { requireRole } from '../helpers/requireRole';
+import { ssm } from '../helpers/ssm';
+import { TableName } from '../helpers/TableName';
+import { isAdminTagEditRequest } from '../types.guard';
+import { demos } from './mux/demos';
+import { applyTagEdits, isMissingParameterError } from './admin/applyTagEdits';
+import { parseTagEdits } from './admin/parseTagEdits';
+import { refreshAfterEdit } from './admin/refreshAfterEdit';
+import { getRoomWithTags } from './rooms/getRoomWithTags';
+
+export const adminUpdateStream: APIGatewayProxyHandlerV2 = catchErrors(async (event) => {
+  if (!TableName) {
+    throw new Error('CACHE_TABLE_NAME not set');
+  }
+
+  if (!(await requireRole(event))) {
+    return accessDenied();
+  }
+
+  const roomId = event.pathParameters?.muxTokenId;
+  if (roomId === undefined || roomId.length === 0) {
+    return notFound();
+  }
+
+  const maybeBody = parseBody(event.body, isAdminTagEditRequest);
+  if (isFailure(maybeBody)) {
+    return invalidRequest('Body must be a tag edit request');
+  }
+
+  const maybePlan = parseTagEdits(successValue(maybeBody), Object.keys(demos));
+  if (isFailure(maybePlan)) {
+    return invalidRequest(maybePlan.value.message);
+  }
+
+  const maybeApplied = await applyTagEdits(ssm, roomId, successValue(maybePlan));
+  if (isFailure(maybeApplied)) {
+    if (isMissingParameterError(maybeApplied.value)) {
+      console.log(`No parameter for ${roomId}`);
+      return notFound();
+    }
+    throw maybeApplied.value;
+  }
+
+  const maybeRefreshed = await refreshAfterEdit(TableName, roomId);
+  if (isFailure(maybeRefreshed)) {
+    throw maybeRefreshed.value;
+  }
+
+  const maybeTags = await getRoomWithTags(ssm, `/multiview/mux/${roomId}`);
+  if (isFailure(maybeTags)) {
+    throw maybeTags.value;
+  }
+
+  return response(
+    {
+      ok: true,
+      stream: { id: roomId, tags: successValue(maybeTags).tags },
+    },
+    200,
+    {
+      'Cache-Control': 'no-cache',
+    },
+  );
+});
+```
+
+- [ ] **Step 5: Export it**
+
+Add to `backend-lambda/src/index.ts`:
+
+```typescript
+export { adminUpdateStream } from './handlers/adminUpdateStream';
+```
+
+- [ ] **Step 6: Verify**
+
+Run from `backend-lambda/`:
+- `./node_modules/.bin/tsc --noEmit` — expected: no output.
+- `./node_modules/.bin/jest` — expected: PASS, 15 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend-lambda/src/handlers/admin/applyTagEdits.ts \
+        backend-lambda/src/handlers/admin/refreshAfterEdit.ts \
+        backend-lambda/src/handlers/adminUpdateStream.ts backend-lambda/src/index.ts
+git commit -m "feat: add POST /admin/streams/{muxTokenId}"
+```
+
+---
+
+### Task 5: CloudFormation wiring
+
+Five separate edits. Missing any of the last two produces routes that deploy cleanly and then fail at runtime.
+
+**Files:**
+- Modify: `infra/main-stack/deployment.cfn.yaml`
+
+**Interfaces:**
+- Consumes: the `adminListStreams` and `adminUpdateStream` exports from Tasks 3 and 4.
+- Produces: `GET /api/admin/streams` and `POST /api/admin/streams/{muxTokenId}`, live on the attendee distribution.
+
+- [ ] **Step 1: Grant the tagging permissions**
+
+In the policy containing `"ssm:GetParametersByPath"` (around line 98), add two actions to the same `Action` list. The existing `parameter/multiview/mux/*` resource entry already covers them, so the `Resource` list is unchanged:
+
+```yaml
+              - "ssm:GetParametersByPath"
+              - "ssm:ListTagsForResource"
+              - "ssm:AddTagsToResource"
+              - "ssm:RemoveTagsFromResource"
+```
+
+- [ ] **Step 2: Add the two functions**
+
+Insert after the `BackendDevtokenFn` block (which ends around line 178), modelled on it:
+
+```yaml
+  BackendAdminListStreamsFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref BackendLambdaS3Bucket
+        S3Key: !Ref BackendLambdaS3Key
+      Handler: src/index.adminListStreams
+      Role: !GetAtt "BackendLambdaRole.Arn"
+      Runtime: "nodejs24.x"
+      Timeout: 25
+      Environment:
+        Variables:
+          CACHE_TABLE_NAME: !Ref "CacheTable"
+          ATTEND_JWT_PRIVATE_KEY: "/multiview/attend/ATTEND_JWT_PRIVATE_KEY"
+          ATTEND_JWT_ISSUER: !Ref "AttendJWTIssuer"
+          ATTEND_JWT_AUDIENCE: !Ref "AttendJWTAudience"
+          ATTEND_JWT_REQUIRED_ROLE: 826205
+
+  BackendAdminUpdateStreamFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref BackendLambdaS3Bucket
+        S3Key: !Ref BackendLambdaS3Key
+      Handler: src/index.adminUpdateStream
+      Role: !GetAtt "BackendLambdaRole.Arn"
+      Runtime: "nodejs24.x"
+      Timeout: 25
+      Environment:
+        Variables:
+          CACHE_TABLE_NAME: !Ref "CacheTable"
+          ABLY_SERVER_KEY: "/multiview/ably/server"
+          ATTEND_JWT_PRIVATE_KEY: "/multiview/attend/ATTEND_JWT_PRIVATE_KEY"
+          ATTEND_JWT_ISSUER: !Ref "AttendJWTIssuer"
+          ATTEND_JWT_AUDIENCE: !Ref "AttendJWTAudience"
+          ATTEND_JWT_REQUIRED_ROLE: 826205
+```
+
+`ABLY_SERVER_KEY` on the update function is load-bearing and fails silently if omitted: `getAblyClient.ts:9` returns `success(undefined)` when it is unset, and the caller only logs "not notifying". The list function does not publish and does not need it.
+
+- [ ] **Step 3: Add integrations and routes**
+
+Insert after `BackendDevtokenRoute` (around line 366):
+
+```yaml
+  BackendAdminListStreamsIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref BackendAPI
+      Description: "Admin: list streams"
+      ConnectionType: INTERNET
+      CredentialsArn: !GetAtt "BackendAPIRole.Arn"
+      PassthroughBehavior: "WHEN_NO_MATCH"
+      TimeoutInMillis: 29000
+      IntegrationMethod: "POST"
+      IntegrationType: "AWS_PROXY"
+      PayloadFormatVersion: "2.0"
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendAdminListStreamsFn.Arn}/invocations"
+
+  BackendAdminListStreamsRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref BackendAPI
+      RouteKey: GET /admin/streams
+      Target: !Sub "integrations/${BackendAdminListStreamsIntegration}"
+
+  BackendAdminUpdateStreamIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref BackendAPI
+      Description: "Admin: update stream tags"
+      ConnectionType: INTERNET
+      CredentialsArn: !GetAtt "BackendAPIRole.Arn"
+      PassthroughBehavior: "WHEN_NO_MATCH"
+      TimeoutInMillis: 29000
+      IntegrationMethod: "POST"
+      IntegrationType: "AWS_PROXY"
+      PayloadFormatVersion: "2.0"
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendAdminUpdateStreamFn.Arn}/invocations"
+
+  BackendAdminUpdateStreamRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref BackendAPI
+      RouteKey: POST /admin/streams/{muxTokenId}
+      Target: !Sub "integrations/${BackendAdminUpdateStreamIntegration}"
+```
+
+`IntegrationMethod: "POST"` is correct for **both** — it is how API Gateway invokes Lambda, not the route's HTTP method. Every existing integration in this file uses it, including the `GET` ones.
+
+- [ ] **Step 4: Add to the deployment DependsOn**
+
+In `BackendAPIDeployment`'s `DependsOn` list (around line 439), add all four:
+
+```yaml
+      - BackendAdminListStreamsRoute
+      - BackendAdminListStreamsIntegration
+      - BackendAdminUpdateStreamRoute
+      - BackendAdminUpdateStreamIntegration
+```
+
+- [ ] **Step 5: Add to the API role**
+
+In `BackendAPIRole`'s `Resource` list (around line 257), add both ARNs:
+
+```yaml
+                  - !GetAtt BackendAdminListStreamsFn.Arn
+                  - !GetAtt BackendAdminUpdateStreamFn.Arn
+```
+
+- [ ] **Step 6: Validate the template**
+
+Run: `python3 -c "import yaml,sys; yaml.SafeLoader.add_multi_constructor('!', lambda l,s,n: None); yaml.safe_load(open('infra/main-stack/deployment.cfn.yaml'))" && echo OK`
+Expected: `OK`. (The loader hook is needed because the template uses CloudFormation short tags like `!Ref` and `!Sub`.)
+
+Then confirm all five edits landed:
+
+```bash
+grep -c "BackendAdminListStreamsFn\|BackendAdminUpdateStreamFn" infra/main-stack/deployment.cfn.yaml
+grep -c "BackendAdminListStreamsRoute\|BackendAdminUpdateStreamRoute" infra/main-stack/deployment.cfn.yaml
+```
+Expected: `6` then `4`.
+
+Six function-name lines: each function appears three times — its definition, its `IntegrationUri`, and its `BackendAPIRole` resource entry. Four route-name lines: each route appears twice — its definition and its `DependsOn` entry. A count of 4 on the first command means Step 5 (the API role) was missed; a count of 2 on the second means Step 4 (the `DependsOn` list) was missed. Both omissions deploy cleanly and fail at runtime, which is why they are checked explicitly.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add infra/main-stack/deployment.cfn.yaml
+git commit -m "feat: wire up admin stream routes"
+```
+
+---
+
+### Task 6: Admin page
+
+**Files:**
+- Create: `frontend/src/admin.html`
+- Create: `frontend/src/js/admin.ts`
+- Create: `frontend/src/js/admin/fetchStreams.ts`
+- Create: `frontend/src/js/admin/saveStream.ts`
+
+**Interfaces:**
+- Consumes: `GET /api/admin/streams` and `POST /api/admin/streams/{muxTokenId}` (Tasks 3, 4); `elm`/`appendChild` from `js/dom.ts`; `AccessDenied` from `js/helpers/AccessDenied.ts`; `Result` helpers from `js/helpers/result.ts`.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the fetch module**
+
+Create `frontend/src/js/admin/fetchStreams.ts`:
+
+```typescript
+import { nanoid } from 'nanoid';
+import { Result, failure, success } from '../helpers/result';
+import { AccessDenied } from '../helpers/AccessDenied';
+
+export type AdminTags = Record<string, string>;
+
+export interface AdminStream {
+  id: string;
+  tags: AdminTags;
+}
+
+export interface AdminStreams {
+  streams: AdminStream[];
+  demos: string[];
+}
+
+interface AdminStreamsResponseOk {
+  ok: true;
+  streams: AdminStream[];
+  demos: string[];
+}
+
+interface AdminStreamsResponseError {
+  ok: false;
+  error: string;
+}
+
+export const fetchStreams = async (): Promise<Result<Error, AdminStreams>> => {
+  try {
+    const fetchResponse = await fetch(`/api/admin/streams?${nanoid()}`, { credentials: 'include' });
+
+    const body = (await fetchResponse.json()) as AdminStreamsResponseOk | AdminStreamsResponseError;
+
+    if (body.ok === false) {
+      if (fetchResponse.status === 403) {
+        throw new AccessDenied(body.error, fetchResponse.status);
+      }
+      throw new Error(body.error);
+    }
+
+    return success({ streams: body.streams, demos: body.demos });
+  } catch (err) {
+    return failure(err as Error);
+  }
+};
+```
+
+- [ ] **Step 2: Write the save module**
+
+Create `frontend/src/js/admin/saveStream.ts`:
+
+```typescript
+import { Result, failure, success } from '../helpers/result';
+import { AccessDenied } from '../helpers/AccessDenied';
+import { AdminTags } from './fetchStreams';
+
+export interface TagEdits {
+  title: string;
+  order: string;
+  show: boolean;
+  demo: string | null;
+}
+
+interface SaveResponseOk {
+  ok: true;
+  stream: { id: string; tags: AdminTags };
+}
+
+interface SaveResponseError {
+  ok: false;
+  error: string;
+}
+
+export const saveStream = async (id: string, edits: TagEdits): Promise<Result<Error, AdminTags>> => {
+  try {
+    const fetchResponse = await fetch(`/api/admin/streams/${encodeURIComponent(id)}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(edits),
+    });
+
+    const body = (await fetchResponse.json()) as SaveResponseOk | SaveResponseError;
+
+    if (body.ok === false) {
+      if (fetchResponse.status === 403) {
+        throw new AccessDenied(body.error, fetchResponse.status);
+      }
+      throw new Error(body.error);
+    }
+
+    return success(body.stream.tags);
+  } catch (err) {
+    return failure(err as Error);
+  }
+};
+```
+
+- [ ] **Step 3: Write the page script**
+
+Create `frontend/src/js/admin.ts`:
+
+```typescript
+import { appendChild, elm } from './dom';
+import { AdminStream, fetchStreams } from './admin/fetchStreams';
+import { saveStream } from './admin/saveStream';
+import { AccessDenied } from './helpers/AccessDenied';
+import { isFailure, successValue } from './helpers/result';
+
+const TAG_TITLE = 'multiview:title';
+const TAG_ORDER = 'multiview:order';
+const TAG_SHOW = 'multiview:show';
+const TAG_DEMO = 'multiview:demo';
+
+const tr = elm('tr');
+const td = elm('td');
+const th = elm('th');
+const table = elm('table');
+const input = elm('input');
+const select = elm('select');
+const option = elm('option');
+const button = elm('button');
+const span = elm('span');
+
+const CELL = 'px-2 py-2 align-middle';
+
+const createRow = (stream: AdminStream, demos: string[]): HTMLTableRowElement => {
+  const titleInput = input([], { type: 'text', class: 'border rounded px-2 py-1 w-64' });
+  titleInput.value = stream.tags[TAG_TITLE] ?? '';
+
+  const orderInput = input([], { type: 'number', class: 'border rounded px-2 py-1 w-20' });
+  orderInput.value = stream.tags[TAG_ORDER] ?? '';
+
+  const showInput = input([], { type: 'checkbox', class: 'w-4 h-4' });
+  showInput.checked = stream.tags[TAG_SHOW] === 'true';
+
+  const demoSelect = select(
+    [option(['(none)'], { value: '' }), ...demos.map((demo) => option([demo], { value: demo }))],
+    { class: 'border rounded px-2 py-1' },
+  );
+  demoSelect.value = stream.tags[TAG_DEMO] ?? '';
+
+  const status = span([''], { class: 'text-sm text-gray-600' });
+
+  const save = button(['Save'], { type: 'button', class: 'bg-blue-600 text-white rounded px-3 py-1' });
+
+  save.addEventListener('click', () => {
+    save.disabled = true;
+    status.textContent = 'Saving…';
+
+    void saveStream(stream.id, {
+      title: titleInput.value,
+      order: orderInput.value,
+      show: showInput.checked,
+      demo: demoSelect.value === '' ? null : demoSelect.value,
+    }).then((result) => {
+      save.disabled = false;
+
+      if (isFailure(result)) {
+        if (result.value instanceof AccessDenied) {
+          window.location.href = '/access-denied.html';
+          return;
+        }
+        status.textContent = `Failed: ${result.value.message}`;
+        return;
+      }
+
+      const tags = successValue(result);
+      titleInput.value = tags[TAG_TITLE] ?? '';
+      orderInput.value = tags[TAG_ORDER] ?? '';
+      showInput.checked = tags[TAG_SHOW] === 'true';
+      demoSelect.value = tags[TAG_DEMO] ?? '';
+      status.textContent = `Saved ${new Date().toLocaleTimeString()}`;
+    });
+  });
+
+  return tr([
+    td([stream.id], { class: `${CELL} font-mono text-sm` }),
+    td([titleInput], { class: CELL }),
+    td([orderInput], { class: CELL }),
+    td([showInput], { class: `${CELL} text-center` }),
+    td([demoSelect], { class: CELL }),
+    td([save], { class: CELL }),
+    td([status], { class: CELL }),
+  ]);
+};
+
+const run = async () => {
+  const root = document.getElementById('streams');
+  const append = appendChild(root);
+
+  const result = await fetchStreams();
+
+  if (isFailure(result)) {
+    if (result.value instanceof AccessDenied) {
+      window.location.href = '/access-denied.html';
+      return;
+    }
+    append(span([`Could not load streams: ${result.value.message}`], { class: 'text-red-700' }));
+    return;
+  }
+
+  const { streams, demos } = successValue(result);
+
+  append(
+    table(
+      [
+        tr(
+          ['Stream', 'Title', 'Order', 'Show', 'Demo', '', ''].map((label) =>
+            th([label], { class: 'px-2 py-2 text-left text-sm font-semibold' }),
+          ),
+        ),
+        ...streams.map((stream) => createRow(stream, demos)),
+      ],
+      { class: 'w-full border-collapse' },
+    ),
+  );
+};
+
+run().catch((err) => console.error('Failed somewhere', err));
+```
+
+- [ ] **Step 4: Write the page**
+
+Create `frontend/src/admin.html`:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>Stream Admin</title>
+
+    <link href="css/attend.css" rel="stylesheet" />
+
+    <script type="module" src="js/admin.ts"></script>
+  </head>
+  <body class="p-6">
+    <h1 class="text-2xl font-semibold mb-1">Stream Admin</h1>
+    <p class="text-sm text-gray-600 mb-6">
+      Only works on <code>live.aws.nextdayvideo.com.au</code> — the monitor domain does not forward
+      the login cookie. Each row saves on its own and refreshes the caches immediately.
+    </p>
+
+    <div id="streams"></div>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: Verify**
+
+Run from `frontend/`:
+- `./node_modules/.bin/tsc --noEmit` — expected: no output.
+- `./node_modules/.bin/prettier --check ./src/js/admin.ts ./src/js/admin/ ./src/admin.html` — expected: all files pass. If it reports changes, run the same command with `--write` and re-check.
+
+Note: `frontend` is `strict: false`, so `appendChild(root)` on a possibly-null element typechecks. Do not add non-null assertions to satisfy a strictness setting this project does not use.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/admin.html frontend/src/js/admin.ts frontend/src/js/admin/
+git commit -m "feat: add stream admin page"
+```
+
+---
+
+### Task 7: End-to-end check against real AWS
+
+There is no offline backend; `frontend/.proxyrc.js` proxies `/api` to production. This task is manual and needs the operator's own credentials.
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Get a fresh cookie**
+
+Authenticate normally in a browser against `live.aws.nextdayvideo.com.au`, then visit `/api/devtoken` and copy the `cookie` value into `NDV_AUD_COOKIE` in the gitignored `frontend/.env`. Tokens expire, so this may need repeating.
+
+- [ ] **Step 2: Run the dev server**
+
+Run from `frontend/`: `./node_modules/.bin/parcel src/*.html`
+
+Open `http://localhost:1234/admin.html`.
+
+- [ ] **Step 3: Check the listing**
+
+Expected: every parameter under `/multiview/mux/` appears, **including any with `multiview:show` unset or `false`** — that is the property that distinguishes this from `/api/stream`. The demo dropdown offers `(none)`, `offline` and `fake-stream`.
+
+Note: this requires the backend to be deployed, since the proxy points at production. Until then, `/api/admin/streams` returns a 404 from API Gateway and the page shows a load error.
+
+- [ ] **Step 4: Check a save round-trip**
+
+Change a title, click Save. Expected: status shows "Saved <time>", and the new title is visible in the AWS console on the parameter's tags.
+
+Then set a stream's demo to `offline` and confirm an open monitor tab reflects it without a reload — that exercises the stream-cache refresh and the Ably publish together, which is the part the plan cannot unit-test.
+
+- [ ] **Step 5: Check the failure paths**
+
+- Enter a non-integer order (e.g. `1.5`) and save. Expected: status shows "Failed: order must be a whole number", and the tag is unchanged.
+- Clear a title and save. Expected: the `multiview:title` tag is removed from the parameter.
+- Set demo back to `(none)`. Expected: the `multiview:demo` tag is removed.
+
+---
+
+## Notes for the implementer
+
+- Adding backend files changes the hash from `backend-lambda/ci/current-object.sh`, so the next push to `main` rebuilds and re-uploads the Lambda zip. That is expected, not a problem.
+- The frontend deploys to a bucket shared by both distributions, so `admin.html` will also be reachable on the monitor domain, where every API call fails. The page says so in its header. Do not add infra to block it — the monitor distribution is deliberately left unauthenticated.
+- If `ts-auto-guard` generates a guard for `AdminTagEditRequest` that rejects `demo: null`, check that `types.ts` declares `demo?: string | null` and not `demo?: string`. The null case is how the UI clears the tag.

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -892,13 +892,29 @@ Five separate edits. Missing any of the last two produces routes that deploy cle
 
 - [ ] **Step 1: Grant the tagging permissions**
 
-In the policy containing `"ssm:GetParametersByPath"` (around line 98), add two actions to the same `Action` list. The existing `parameter/multiview/mux/*` resource entry already covers them, so the `Resource` list is unchanged:
+Add a **new** policy rather than extending `CanReadFromSSM`. That policy's `Resource` list also covers
+the ably and attend paths, so adding write actions there would grant tagging on secrets the admin UI
+has no reason to touch — and would leave a policy named "CanReadFromSSM" granting writes. Insert
+after the `CanReadFromSSM` resource:
 
 ```yaml
-              - "ssm:GetParametersByPath"
-              - "ssm:ListTagsForResource"
+  # Separate from CanReadFromSSM so tagging stays scoped to the mux parameters --
+  # the admin UI has no reason to retag the ably or attend secrets.
+  CanTagMuxParameters:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CanTagMuxParameters"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
               - "ssm:AddTagsToResource"
               - "ssm:RemoveTagsFromResource"
+            Resource:
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/multiview/mux/*"
+      Roles:
+        - !Ref "BackendLambdaRole"
 ```
 
 - [ ] **Step 2: Add the two functions**

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -616,7 +616,11 @@ export { adminListStreams } from './handlers/adminListStreams';
 Run from `backend-lambda/`: `./node_modules/.bin/tsc --noEmit`
 Expected: no output.
 
-If `nextToken` produces an implicit-any or type-widening error under `strict`, keep the explicit `let nextToken: string | undefined = undefined;` annotation shown above — do not switch to `while (true)` with a `break`.
+The `page` annotation is required, not stylistic. Without it `tsc` fails with `TS7022: 'page'
+implicitly has type 'any' because it is referenced directly or indirectly in its own initializer` —
+`nextToken` is assigned from `page`, which comes from a call that takes `nextToken`. Keep both the
+`GetParametersByPathResult` annotation and the explicit `let nextToken: string | undefined`; do not
+switch to `while (true)` with a `break`.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -237,8 +237,14 @@ module.exports = {
 Add a `test` script to `backend-lambda/package.json`, immediately after the `"watch"` line:
 
 ```json
-    "test": "jest",
+    "test": "ts-auto-guard --debug && jest",
 ```
+
+The `ts-auto-guard` call is not optional. `src/types.guard.ts` is generated **and gitignored**, so a
+fresh clone does not have it — and `helpers/verifyToken.ts` imports it, which means any test that
+transitively reaches a handler fails with `Cannot find module '../types.guard'`. Generating it as
+part of `test` fixes CI and a fresh local clone in one place. Running `./node_modules/.bin/jest`
+directly skips this, which is fine once the file exists.
 
 In `backend-lambda/tsconfig.json`, change the `exclude` array so test files are never emitted into `dist/` (and therefore never shipped inside `build.zip`):
 

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -188,17 +188,51 @@ The pure core of the feature. Sets up the jest harness because this is the first
 
 - [ ] **Step 1: Set up the jest harness**
 
-`jest`, `@types/jest` and `ts-jest` are already devDependencies — no installs needed.
+**Do not use the `ts-jest` devDependency, despite it already being present.** ts-jest 29 cannot
+drive the TypeScript 7 compiler API this project pins — it fails with "does not expose the
+JavaScript compiler API required by ts-jest" and suggests aliasing a TypeScript 6 package.
+Downgrading TypeScript is the wrong fix. Use `@swc/jest`, which is what `frontend/jest.config.js`
+already uses.
+
+That needs two devDependencies. The registry is unreachable in this sandbox, so install from pnpm's
+local content-addressed store, which already has them because the frontend uses them:
+
+```bash
+pnpm add -D --offline @swc/core@^1.15.46 @swc/jest@^0.2.39
+```
+
+Expected: `+ @swc/core` and `+ @swc/jest`, with `package.json` and `pnpm-lock.yaml` both updated. The
+`ERR_PNPM_IGNORED_BUILDS` warning about `@swc/core` build scripts is fine — the native binary ships
+as a platform-specific optional dependency, not from a build script.
 
 Create `backend-lambda/jest.config.js`:
 
 ```javascript
 module.exports = {
   testEnvironment: 'node',
-  preset: 'ts-jest',
-  testMatch: ['**/*.test.ts'],
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  // dist/ holds a copy of package.json after a build, which jest's haste map
+  // reports as a duplicate of the real one.
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  // @swc/jest rather than ts-jest: ts-jest 29 cannot use the TypeScript 7
+  // compiler API this project pins. Matches frontend/jest.config.js.
+  transform: {
+    '^.+\\.ts$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript' },
+          target: 'es2020',
+        },
+      },
+    ],
+  },
 };
 ```
+
+`@swc/jest` transpiles without type-checking, and the `exclude` below keeps test files out of
+`tsc`'s program — so **test files are not type-checked by anything**. That is the same trade
+`frontend` already makes. `tsc --noEmit` still covers all non-test source.
 
 Add a `test` script to `backend-lambda/package.json`, immediately after the `"watch"` line:
 
@@ -355,11 +389,15 @@ describe('parseTagEdits', () => {
 Run from `backend-lambda/`: `./node_modules/.bin/jest`
 Expected: FAIL — cannot resolve `./parseTagEdits`.
 
-If instead ts-jest reports that the test file is not part of the TypeScript project, that is the
-`**/*.test.ts` exclude added in Step 1 (ts-jest reads the same `tsconfig.json`). The fix is a
-`tsconfig.test.json` that extends the base config and re-includes `src/**/*.ts`, pointed at from
-`jest.config.js` via `transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }] }`.
-Do **not** remove the exclude — it is what keeps test files out of `build.zip`.
+`@swc/jest` does not read `tsconfig.json`, so the `**/*.test.ts` exclude added in Step 1 does not
+affect the test run. Confirm the exclude is doing its job with:
+
+```bash
+./node_modules/.bin/tsc --noEmit --listFiles | grep -c "parseTagEdits.test.ts"
+```
+
+Expected: `0`. A non-zero count means test files would be emitted into `dist/` and shipped inside
+`build.zip`.
 
 - [ ] **Step 6: Implement**
 

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -349,6 +349,12 @@ describe('parseTagEdits', () => {
 Run from `backend-lambda/`: `./node_modules/.bin/jest`
 Expected: FAIL — cannot resolve `./parseTagEdits`.
 
+If instead ts-jest reports that the test file is not part of the TypeScript project, that is the
+`**/*.test.ts` exclude added in Step 1 (ts-jest reads the same `tsconfig.json`). The fix is a
+`tsconfig.test.json` that extends the base config and re-includes `src/**/*.ts`, pointed at from
+`jest.config.js` via `transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }] }`.
+Do **not** remove the exclude — it is what keeps test files out of `build.zip`.
+
 - [ ] **Step 6: Implement**
 
 Create `backend-lambda/src/handlers/admin/parseTagEdits.ts`:
@@ -604,6 +610,8 @@ grep -rn "InvalidResourceId" node_modules/@aws-sdk/client-ssm/dist-types/models/
 
 Expected: a hit for an `InvalidResourceId` exception class. The AWS SDK sets `err.name` to the exception's shape name. If the grep finds nothing, list the exceptions the operation declares and use the correct name in Step 2 instead of `InvalidResourceId`. Do not use `ParameterNotFound` — that belongs to the `GetParameter` family, not the tagging APIs.
 
+Also confirm that `removeTagsFromResource` is a no-op when a listed `TagKeys` entry is not present on the parameter. This matters because clearing a title on a stream that never had a `multiview:title` tag sends exactly that. AWS tag-removal APIs are normally idempotent, so no-op is the expected answer. If it turns out to raise instead, change `adminUpdateStream` (Step 4) to call `getRoomWithTags` *before* `applyTagEdits` and filter `plan.remove` down to keys that are actually present — do not silently swallow the error.
+
 - [ ] **Step 2: Implement the tag write**
 
 Create `backend-lambda/src/handlers/admin/applyTagEdits.ts`:
@@ -760,9 +768,13 @@ export const adminUpdateStream: APIGatewayProxyHandlerV2 = catchErrors(async (ev
     throw maybeApplied.value;
   }
 
+  // The tags are already committed. A refresh failure must not be reported as a
+  // failed save: getStreamStateFromDynamo reaches Mux, so clearing multiview:demo
+  // on a stream that is not currently live fails here for a save that landed
+  // correctly. Report it separately and let the 60s TTL catch up.
   const maybeRefreshed = await refreshAfterEdit(TableName, roomId);
   if (isFailure(maybeRefreshed)) {
-    throw maybeRefreshed.value;
+    console.log(`Tags written for ${roomId} but the refresh failed`, maybeRefreshed.value);
   }
 
   const maybeTags = await getRoomWithTags(ssm, `/multiview/mux/${roomId}`);
@@ -773,6 +785,7 @@ export const adminUpdateStream: APIGatewayProxyHandlerV2 = catchErrors(async (ev
   return response(
     {
       ok: true,
+      refreshed: !isFailure(maybeRefreshed),
       stream: { id: roomId, tags: successValue(maybeTags).tags },
     },
     200,
@@ -1043,14 +1056,23 @@ import { AccessDenied } from '../helpers/AccessDenied';
 import { AdminTags } from './fetchStreams';
 
 export interface TagEdits {
-  title: string;
-  order: string;
+  title?: string;
+  // Omitted entirely when the field is blank. A stream with no multiview:order tag
+  // is a supported state (getOrderFromTag defaults it), and sending '' would fail
+  // validation on every save, even one that only changed the title.
+  order?: string;
   show: boolean;
   demo: string | null;
 }
 
+export interface SavedStream {
+  tags: AdminTags;
+  refreshed: boolean;
+}
+
 interface SaveResponseOk {
   ok: true;
+  refreshed: boolean;
   stream: { id: string; tags: AdminTags };
 }
 
@@ -1059,7 +1081,7 @@ interface SaveResponseError {
   error: string;
 }
 
-export const saveStream = async (id: string, edits: TagEdits): Promise<Result<Error, AdminTags>> => {
+export const saveStream = async (id: string, edits: TagEdits): Promise<Result<Error, SavedStream>> => {
   try {
     const fetchResponse = await fetch(`/api/admin/streams/${encodeURIComponent(id)}`, {
       method: 'POST',
@@ -1077,12 +1099,14 @@ export const saveStream = async (id: string, edits: TagEdits): Promise<Result<Er
       throw new Error(body.error);
     }
 
-    return success(body.stream.tags);
+    return success({ tags: body.stream.tags, refreshed: body.refreshed });
   } catch (err) {
     return failure(err as Error);
   }
 };
 ```
+
+`JSON.stringify` drops keys whose value is `undefined`, so an omitted `order` or `title` never reaches the backend and `parseTagEdits` leaves that tag alone.
 
 - [ ] **Step 3: Write the page script**
 
@@ -1138,7 +1162,9 @@ const createRow = (stream: AdminStream, demos: string[]): HTMLTableRowElement =>
 
     void saveStream(stream.id, {
       title: titleInput.value,
-      order: orderInput.value,
+      // Blank order means "no multiview:order tag", which is a valid state — send
+      // nothing rather than '' so an untouched blank order cannot fail the save.
+      order: orderInput.value === '' ? undefined : orderInput.value,
       show: showInput.checked,
       demo: demoSelect.value === '' ? null : demoSelect.value,
     }).then((result) => {
@@ -1153,12 +1179,14 @@ const createRow = (stream: AdminStream, demos: string[]): HTMLTableRowElement =>
         return;
       }
 
-      const tags = successValue(result);
+      const { tags, refreshed } = successValue(result);
       titleInput.value = tags[TAG_TITLE] ?? '';
       orderInput.value = tags[TAG_ORDER] ?? '';
       showInput.checked = tags[TAG_SHOW] === 'true';
       demoSelect.value = tags[TAG_DEMO] ?? '';
-      status.textContent = `Saved ${new Date().toLocaleTimeString()}`;
+      status.textContent = refreshed
+        ? `Saved ${new Date().toLocaleTimeString()}`
+        : `Saved ${new Date().toLocaleTimeString()} — cache refresh failed, may take 60s`;
     });
   });
 
@@ -1284,6 +1312,8 @@ Then set a stream's demo to `offline` and confirm an open monitor tab reflects i
 - Enter a non-integer order (e.g. `1.5`) and save. Expected: status shows "Failed: order must be a whole number", and the tag is unchanged.
 - Clear a title and save. Expected: the `multiview:title` tag is removed from the parameter.
 - Set demo back to `(none)`. Expected: the `multiview:demo` tag is removed.
+- On a stream with **no** `multiview:order` tag (remove it in the console if none exists), change only the title and save. Expected: success. A `400 order must be a whole number` here means the blank-order omission in Task 6 Step 3 was dropped.
+- Set a demo on a stream that is **not** currently live, then clear it and save. Expected: status shows "Saved … — cache refresh failed, may take 60s" or a plain "Saved", but never "Failed". The tags must be correct in the console either way. A "Failed" here means the non-fatal refresh handling in Task 4 Step 4 was dropped.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
+++ b/docs/superpowers/plans/2026-08-14-stream-admin-ui.md
@@ -24,6 +24,12 @@
 - Never return an SSM parameter *value* to a client. Values under `/multiview/mux/` are Mux token secrets.
 - Do not add routes to the monitor CloudFront distribution. It is deliberately unauthenticated (on-site event use); only the attendee distribution forwards cookies.
 - Commit after every task.
+- **Never write to AWS.** No `aws` CLI mutations, no CloudFormation deploys, no SSM tag writes, no
+  running the `TEST_HANDLER` blocks (they hit real AWS through the default credential chain).
+  Deployment happens only by merging to `main`. Tasks 1–6 are done on a branch and end at a pull
+  request; Task 7 is Sophie's, after the merge deploys.
+- Verification available in-session is limited to `tsc --noEmit`, `jest`, `prettier` and static
+  checks of the CloudFormation template. Nothing else may be claimed as verified.
 
 ## File Structure
 
@@ -1279,9 +1285,16 @@ git commit -m "feat: add stream admin page"
 
 ---
 
-### Task 7: End-to-end check against real AWS
+### Task 7: End-to-end check — POST-MERGE, SOPHIE ONLY
 
-There is no offline backend; `frontend/.proxyrc.js` proxies `/api` to production. This task is manual and needs the operator's own credentials.
+> **Not for the implementing agent.** Every step below needs AWS credentials and deployed
+> infrastructure. Agents must not attempt any of it, and must not report any of it as verified.
+> Tasks 1–6 end at a pull request; this task starts after that PR is merged and
+> `.github/workflows/main.yaml` has deployed.
+
+There is no offline backend — `frontend/.proxyrc.js` proxies `/api` to **production**. So the admin
+endpoints do not exist anywhere until the backend change is merged and deployed, and running the dev
+server before then shows a load error on the page. That is expected, not a bug to chase.
 
 **Files:** none — verification only.
 

--- a/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
@@ -1,0 +1,236 @@
+# Stream admin UI — design
+
+**Date:** 2026-08-14
+**Status:** Approved, ready for implementation planning
+
+## Purpose
+
+Give someone running an event a web page to edit the SSM tags that control which streams appear
+in the monitor and attendee apps, without needing AWS console access or the CLI. Every edit must
+leave the caches correct immediately, so a change made mid-event is visible right away.
+
+## Scope
+
+In scope: editing the four `multiview:*` tags on parameters that already exist under
+`/multiview/mux/` in `us-east-1`, and refreshing caches after each edit.
+
+Out of scope, by decision:
+
+- Creating or deleting streams. Creating a parameter means writing a Mux token secret through the
+  web app; six years of running this have needed no more than five streams, and adding one by hand
+  is acceptable.
+- Editing the parameter value (the Mux token secret) itself.
+
+## Decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Which distribution hosts the page | Attendee (`live.aws.nextdayvideo.com.au`) | It is the only distribution whose `/api/*` behaviour forwards cookies (see below). |
+| Refresh scope after an edit | Rooms cache + that stream's cache + Ably publish | `multiview:demo` and `multiview:title` feed the per-stream cache, which `/api/refresh` does not touch. |
+| Role gating | Reuse `ATTEND_JWT_REQUIRED_ROLE` | Matches `/api/devtoken`; one group of trusted operators. |
+| API shape | Two routes, per-room save | Localises failures to one room; avoids partial-batch semantics. |
+| Testing | Wire up jest, unit-test the pure logic | AWS paths have no mocks in this repo and are not worth building for a helper UI. |
+
+### Why the attendee distribution
+
+The monitor distribution's `/api/*` cache behaviour
+(`infra/main-stack/deployment.cfn.yaml:513-528`) uses the `Managed-CachingDisabled` cache policy and
+sets **no** `OriginRequestPolicyId`, so CloudFront forwards no cookies to API Gateway. The attendee
+distribution's equivalent (line 648) sets `Managed-AllViewerExceptHostHeader`. Cookie-authenticated
+`/api/*` calls therefore only work on the attendee domain today. That domain is also what
+`frontend/.proxyrc.js` proxies to, so local development exercises the same path.
+
+Consequence: the S3 bucket is shared between both distributions, so `admin.html` will also be
+reachable at `mux-monitor.aws.nextdayvideo.com.au/admin.html`, where it will load and then fail
+every API call. This is noted on the page rather than blocked in infra.
+
+## Backend
+
+### New files
+
+```
+backend-lambda/src/
+  helpers/requireRole.ts                    extracted from devtoken.ts:14-36
+  handlers/adminListStreams.ts              GET  /admin/streams
+  handlers/adminUpdateStream.ts             POST /admin/streams/{muxTokenId}
+  handlers/admin/AdminStream.ts             types
+  handlers/admin/listStreamsFromSSM.ts      unfiltered, paginated listing
+  handlers/admin/parseTagEdits.ts           pure validation/coercion
+  handlers/admin/applyTagEdits.ts           SSM Add/RemoveTagsFromResource
+  handlers/admin/refreshAfterEdit.ts        rooms + stream + Ably
+```
+
+Modified: `src/index.ts` (two re-exports), `src/types.ts` and the regenerated `src/types.guard.ts`
+(request body guard), `src/handlers/devtoken.ts` (switch to the shared helper).
+
+### `helpers/requireRole.ts`
+
+Extracted verbatim from the current `devtoken.ts` so behaviour is unchanged: call
+`verifyTokenCookie(event, true)`; return `undefined` if there is no valid token, if
+`ATTEND_JWT_REQUIRED_ROLE` is empty, or if the token's role matches none of the configured roles;
+otherwise return `{ cookie, token }`. Handlers call it and return `accessDenied()` on `undefined`.
+`devtoken.ts` is rewritten to use it, dropping about twelve lines.
+
+### Listing
+
+`listStreamsFromSSM.ts` calls `ssm.getParametersByPath({ Path: '/multiview/mux/' })` and **paginates
+on `NextToken`**. The existing `getRoomsFromSSM.ts:15` does not paginate, so it silently caps at
+SSM's default of 10 results; an admin list that truncates without saying so is a bad failure mode.
+Tags come from the existing `getRoomWithTags`, dispatched through a `PQueue({ concurrency: 4 })`
+exactly as `getRoomsFromSSM.ts:9` does.
+
+`getParametersByPath` returns parameter *values*, which here are Mux token secrets. The
+`AdminStream` type carries only `{ id, tags }` — no value field exists to populate — so secrets
+never enter the response. `ssm:DescribeParameters` would avoid fetching them at all, but IAM does
+not support resource-level permissions for that action; granting it would mean `Resource: "*"`,
+widening the Lambda role from three `/multiview/*` paths to metadata on every parameter in the
+account. Not a worthwhile trade, and `getParametersByPath` is already what the existing code calls.
+
+This deliberately does not reuse `Room` or the `rooms/all` cache. Both filter to
+`tags['multiview:show'] === 'true'` (`getRoomsFromSSM.ts:44`), so a room that had just been hidden
+would disappear from the editor and become unrecoverable. Admin reads go straight to SSM every time.
+
+`GET /admin/streams` responds with:
+
+```json
+{ "ok": true,
+  "streams": [ { "id": "<muxTokenId>", "tags": { "multiview:title": "…", "multiview:order": "1",
+                                                 "multiview:show": "true", "multiview:demo": "offline" } } ],
+  "demos": ["offline", "fake-stream"] }
+```
+
+`demos` is `Object.keys(demos)` from `handlers/mux/demos.ts`. The frontend builds its demo dropdown
+from this list rather than hardcoding the options, so the two cannot drift apart. Streams are sorted
+by `multiview:order`, then by id, so the table order is stable across reloads.
+
+### Tag semantics
+
+| Tag | Accepted from client | Written as | Cleared when |
+|---|---|---|---|
+| `multiview:title` | string | trimmed string | empty after trim → tag removed |
+| `multiview:order` | number or numeric string | `String(parseInt(v, 10))` | never; non-integer → 400 |
+| `multiview:show` | boolean | literal `"true"` / `"false"` | never |
+| `multiview:demo` | validated against `Object.keys(demos)` | the string | `null` → tag removed |
+
+`multiview:show` is written as a literal string because the read path is a string comparison.
+`multiview:demo` is validated against `handlers/mux/demos.ts` rather than a second hardcoded list,
+so adding a demo there makes it selectable automatically. An empty title is dropped rather than
+written as `""`, matching `getRoomWithTags.ts`, which already discards falsy tag values.
+
+Clearing a tag is a `RemoveTagsFromResource` call, not an `AddTagsToResource` with an empty value.
+`applyTagEdits` therefore makes up to two SSM calls: one add for tags being set, one remove for keys
+being cleared.
+
+### Data flow for a save
+
+```
+POST /admin/streams/{muxTokenId}
+  → requireRole                         403 if not satisfied
+  → parseBody + generated type guard    400 if malformed
+  → parseTagEdits (pure)                400 if a value is invalid
+  → applyTagEdits (SSM add/remove)
+  → refreshAfterEdit
+      getRoomsFromDynamo(TableName, true)
+      getStreamStateFromDynamo(TableName, roomId, true)
+      Ably publish to 'mux-monitor.aws.nextdayvideo.com.au'
+        { roomId, why: 'admin-edit', ...state }
+  → 200 with the room's new tag state
+```
+
+The Ably payload matches the shape `muxWebhook.ts:56` publishes, so existing subscribers need no
+change.
+
+## Error handling
+
+- No or invalid cookie, or wrong role → `accessDenied()` (403). The frontend redirects to
+  `/access-denied.html`.
+- A path parameter that is missing or empty → `notFound()` (404), as `muxWebhook.ts:18-21` does.
+- Unknown `muxTokenId` → `notFound()` (404). Detected by catching SSM's `InvalidResourceId` from the
+  tag write — that is the error `AddTagsToResource`/`RemoveTagsFromResource` raise for a missing
+  target, not `ParameterNotFound`, which belongs to the `GetParameter` family. There is no separate
+  existence check, so there is no time-of-check/time-of-use gap. Confirm the exact error name
+  against the SDK during implementation before relying on it.
+- Malformed body or an invalid tag value → `invalidRequest()` (400) naming the offending field.
+- SSM write failure → propagates through `catchErrors` as a 500; nothing has been cached, so a retry
+  is safe.
+- **Ably publish failure is logged and not fatal.** By that point the tags are written and both
+  caches are refreshed. Returning 500 would report a failed save that actually succeeded. This
+  mirrors `muxWebhook.ts:47-49`.
+
+## Infra
+
+`infra/main-stack/deployment.cfn.yaml`:
+
+1. `BackendLambdaRole` policy gains `ssm:AddTagsToResource` and `ssm:RemoveTagsFromResource`. The
+   existing `parameter/multiview/mux/*` resource entry already covers them;
+   `ssm:GetParametersByPath` and `ssm:ListTagsForResource` are already granted.
+2. Two `AWS::Lambda::Function` resources modelled on `BackendDevtokenFn` (line 161):
+
+   | | `BackendAdminListStreamsFn` | `BackendAdminUpdateStreamFn` |
+   |---|---|---|
+   | Handler | `src/index.adminListStreams` | `src/index.adminUpdateStream` |
+   | Env | `CACHE_TABLE_NAME`, `ATTEND_JWT_PRIVATE_KEY`, `ATTEND_JWT_ISSUER`, `ATTEND_JWT_AUDIENCE`, `ATTEND_JWT_REQUIRED_ROLE` | the same, plus `ABLY_SERVER_KEY: /multiview/ably/server` |
+
+   `ABLY_SERVER_KEY` on the update function is the one omission that deploys clean and fails
+   silently: `getAblyClient.ts:9` returns `success(undefined)` when it is unset, and the caller only
+   logs "not notifying".
+3. `BackendAdminListStreamsIntegration` + `BackendAdminListStreamsRoute` (`GET /admin/streams`), and
+   `BackendAdminUpdateStreamIntegration` + `BackendAdminUpdateStreamRoute`
+   (`POST /admin/streams/{muxTokenId}`).
+4. All four added to `BackendAPIDeployment`'s `DependsOn` list.
+5. Both function ARNs added to `BackendAPIRole`'s resource list.
+
+Items 4 and 5 are the ones that otherwise produce a route that deploys but fails at runtime. The
+API's existing `CorsConfiguration` already allows GET and POST, so it needs no change.
+
+## Frontend
+
+New: `src/admin.html`, `src/js/admin.ts`, `src/js/admin/fetchStreams.ts`,
+`src/js/admin/saveStream.ts` — mirroring how `fetchRooms.ts` isolates its fetch from the page logic.
+Parcel picks up `src/*.html` automatically, so no build config changes.
+
+The page links `css/attend.css`, the Tailwind entry point the other attendee-side pages use.
+
+One table, one row per stream, with title (text), order (number), show (checkbox) and demo (select:
+*none* / `offline` / `fake-stream`, with options built from the API response so they track
+`demos.ts`). Save is per row, with per-row status text; the button is disabled while a request is in
+flight. A 403 response redirects to `/access-denied.html` using the existing `helpers/AccessDenied.ts`
+pattern from `index.ts:20-23`.
+
+## Testing
+
+`backend-lambda` already lists `jest`, `@types/jest` and `ts-jest` as devDependencies but has no
+config, no `test` script and no test files. Add a `jest.config.js` using ts-jest and a
+`"test": "jest"` script — no new packages.
+
+Unit tests cover the pure logic:
+
+- `parseTagEdits.ts`: order coercion from number and numeric string; non-integer order rejected;
+  show written as literal `"true"`/`"false"`; demo validated against `demos`; unknown demo rejected;
+  `null` demo and empty title produce removals.
+- The resulting add/remove call plan: which keys go to `AddTagsToResource` and which to
+  `RemoveTagsFromResource`.
+
+The AWS-touching paths stay untested; no mocking layer exists in this repo and building one for a
+helper UI is not proportionate.
+
+**Build hazard:** `tsconfig.json` includes `src/**/*.ts` with `outDir: dist`, and `build.prepare`
+only removes `dist/test`. Colocated `*.test.ts` files would compile into `dist/` and ship inside
+`build.zip`. Add `"**/*.test.ts"` to the tsconfig `exclude` list.
+
+Adding files changes the hash computed by `backend-lambda/ci/current-object.sh`, which correctly
+triggers one backend rebuild on deploy.
+
+## Verification
+
+Run the binaries directly; `pnpm run <script>` hangs in a network-restricted sandbox.
+
+```
+backend-lambda/  ./node_modules/.bin/tsc --noEmit
+backend-lambda/  ./node_modules/.bin/jest
+frontend/        ./node_modules/.bin/tsc --noEmit
+```
+
+Manual check against real AWS through the dev proxy: `pnpm start` in `frontend/` with a fresh
+`NDV_AUD_COOKIE`, open `/admin.html`, edit a tag, confirm the change lands in SSM and that an open
+monitor tab updates without a reload.

--- a/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
@@ -153,9 +153,14 @@ change.
 - Malformed body or an invalid tag value → `invalidRequest()` (400) naming the offending field.
 - SSM write failure → propagates through `catchErrors` as a 500; nothing has been cached, so a retry
   is safe.
-- **Ably publish failure is logged and not fatal.** By that point the tags are written and both
-  caches are refreshed. Returning 500 would report a failed save that actually succeeded. This
-  mirrors `muxWebhook.ts:47-49`.
+- **Nothing after the SSM write is fatal.** Once `applyTagEdits` returns, the tags are committed and
+  the save has succeeded; reporting a 500 after that point would tell the operator their change did
+  not land when it did. So both the cache refresh and the Ably publish are logged on failure and the
+  response is still 200, carrying `refreshed: true|false` so the row can say "cache refresh failed,
+  may take 60s". This matters in practice, not just in theory: `getStreamStateFromDynamo` reaches
+  Mux through `makeGetStreamStateFromSSMAndMux`, which fails whenever `getStreamURL` does — so
+  clearing `multiview:demo` on a stream that is not currently live would otherwise report a failed
+  save. The Ably half mirrors `muxWebhook.ts:47-49`.
 
 ## Infra
 

--- a/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
+++ b/docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md
@@ -236,6 +236,11 @@ backend-lambda/  ./node_modules/.bin/jest
 frontend/        ./node_modules/.bin/tsc --noEmit
 ```
 
-Manual check against real AWS through the dev proxy: `pnpm start` in `frontend/` with a fresh
-`NDV_AUD_COOKIE`, open `/admin.html`, edit a tag, confirm the change lands in SSM and that an open
-monitor tab updates without a reload.
+That is the whole of the automated gate. Nothing here can be verified against AWS in-session: this
+repo deploys only by merging to `main`, and `.proxyrc.js` proxies `/api` to production, so the admin
+endpoints do not exist until the change is deployed.
+
+The end-to-end check is therefore **post-merge and Sophie's**: `pnpm start` in `frontend/` with a
+fresh `NDV_AUD_COOKIE`, open `/admin.html`, edit a tag, confirm the change lands in SSM and that an
+open monitor tab updates without a reload. Task 7 of the implementation plan lists the specific
+cases.

--- a/frontend/src/admin.html
+++ b/frontend/src/admin.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Stream Admin</title>
+
+    <link href="css/attend.css" rel="stylesheet" />
+
+    <script type="module" src="js/admin.ts"></script>
+  </head>
+  <body class="p-6">
+    <h1 class="text-2xl font-semibold mb-1">Stream Admin</h1>
+    <p class="text-sm text-gray-600 mb-6">
+      Only works on <code>live.aws.nextdayvideo.com.au</code> — the monitor domain does not forward the login cookie.
+      Each row saves on its own and refreshes the caches immediately.
+    </p>
+
+    <div id="streams"></div>
+  </body>
+</html>

--- a/frontend/src/js/admin.ts
+++ b/frontend/src/js/admin.ts
@@ -1,0 +1,123 @@
+import { appendChild, elm } from './dom';
+import { AdminStream, fetchStreams } from './admin/fetchStreams';
+import { saveStream } from './admin/saveStream';
+import { AccessDenied } from './helpers/AccessDenied';
+import { isFailure, successValue } from './helpers/result';
+
+const TAG_TITLE = 'multiview:title';
+const TAG_ORDER = 'multiview:order';
+const TAG_SHOW = 'multiview:show';
+const TAG_DEMO = 'multiview:demo';
+
+const tr = elm('tr');
+const td = elm('td');
+const th = elm('th');
+const table = elm('table');
+const input = elm('input');
+const select = elm('select');
+const option = elm('option');
+const button = elm('button');
+const span = elm('span');
+
+const CELL = 'px-2 py-2 align-middle border-b border-gray-200';
+
+const createRow = (stream: AdminStream, demos: string[]): HTMLTableRowElement => {
+  const titleInput = input([], { type: 'text', class: 'border rounded px-2 py-1 w-64' });
+  titleInput.value = stream.tags[TAG_TITLE] ?? '';
+
+  const orderInput = input([], { type: 'number', class: 'border rounded px-2 py-1 w-20' });
+  orderInput.value = stream.tags[TAG_ORDER] ?? '';
+
+  const showInput = input([], { type: 'checkbox', class: 'w-4 h-4' });
+  showInput.checked = stream.tags[TAG_SHOW] === 'true';
+
+  const demoSelect = select(
+    [option(['(none)'], { value: '' }), ...demos.map((demo) => option([demo], { value: demo }))],
+    {
+      class: 'border rounded px-2 py-1',
+    },
+  );
+  demoSelect.value = stream.tags[TAG_DEMO] ?? '';
+
+  const status = span([''], { class: 'text-sm text-gray-600' });
+
+  const save = button(['Save'], { type: 'button', class: 'bg-blue-600 text-white rounded px-3 py-1' });
+
+  save.addEventListener('click', () => {
+    save.disabled = true;
+    status.textContent = 'Saving…';
+
+    void saveStream(stream.id, {
+      title: titleInput.value,
+      // Blank order means "no multiview:order tag", which is a valid state — send
+      // nothing rather than '' so an untouched blank order cannot fail the save.
+      order: orderInput.value === '' ? undefined : orderInput.value,
+      show: showInput.checked,
+      demo: demoSelect.value === '' ? null : demoSelect.value,
+    }).then((result) => {
+      save.disabled = false;
+
+      if (isFailure(result)) {
+        if (result.value instanceof AccessDenied) {
+          window.location.href = '/access-denied.html';
+          return;
+        }
+        status.textContent = `Failed: ${result.value.message}`;
+        return;
+      }
+
+      const { tags, refreshed } = successValue(result);
+      titleInput.value = tags[TAG_TITLE] ?? '';
+      orderInput.value = tags[TAG_ORDER] ?? '';
+      showInput.checked = tags[TAG_SHOW] === 'true';
+      demoSelect.value = tags[TAG_DEMO] ?? '';
+      status.textContent = refreshed
+        ? `Saved ${new Date().toLocaleTimeString()}`
+        : `Saved ${new Date().toLocaleTimeString()} — cache refresh failed, may take 60s`;
+    });
+  });
+
+  return tr([
+    td([stream.id], { class: `${CELL} font-mono text-sm` }),
+    td([titleInput], { class: CELL }),
+    td([orderInput], { class: CELL }),
+    td([showInput], { class: `${CELL} text-center` }),
+    td([demoSelect], { class: CELL }),
+    td([save], { class: CELL }),
+    td([status], { class: CELL }),
+  ]);
+};
+
+const run = async () => {
+  const root = document.getElementById('streams');
+  const append = appendChild(root);
+
+  const result = await fetchStreams();
+
+  if (isFailure(result)) {
+    if (result.value instanceof AccessDenied) {
+      window.location.href = '/access-denied.html';
+      return;
+    }
+    append(span([`Could not load streams: ${result.value.message}`], { class: 'text-red-700' }));
+    return;
+  }
+
+  const { streams, demos } = successValue(result);
+
+  append(
+    table(
+      [
+        tr(
+          ['Stream', 'Title', 'Order', 'Show', 'Demo', '', ''].map((label) =>
+            th([label], { class: 'px-2 py-2 text-left text-sm font-semibold border-b-2 border-gray-300' }),
+          ),
+        ),
+        ...streams.map((stream) => createRow(stream, demos)),
+      ],
+      { class: 'w-full border-collapse' },
+    ),
+  );
+};
+
+run().catch((err) => console.error('Failed somewhere', err));

--- a/frontend/src/js/admin/fetchStreams.ts
+++ b/frontend/src/js/admin/fetchStreams.ts
@@ -1,0 +1,45 @@
+import { nanoid } from 'nanoid';
+import { Result, failure, success } from '../helpers/result';
+import { AccessDenied } from '../helpers/AccessDenied';
+
+export type AdminTags = Record<string, string>;
+
+export interface AdminStream {
+  id: string;
+  tags: AdminTags;
+}
+
+export interface AdminStreams {
+  streams: AdminStream[];
+  demos: string[];
+}
+
+interface AdminStreamsResponseOk {
+  ok: true;
+  streams: AdminStream[];
+  demos: string[];
+}
+
+interface AdminStreamsResponseError {
+  ok: false;
+  error: string;
+}
+
+export const fetchStreams = async (): Promise<Result<Error, AdminStreams>> => {
+  try {
+    const fetchResponse = await fetch(`/api/admin/streams?${nanoid()}`, { credentials: 'include' });
+
+    const body = (await fetchResponse.json()) as AdminStreamsResponseOk | AdminStreamsResponseError;
+
+    if (body.ok === false) {
+      if (fetchResponse.status === 403) {
+        throw new AccessDenied(body.error, fetchResponse.status);
+      }
+      throw new Error(body.error);
+    }
+
+    return success({ streams: body.streams, demos: body.demos });
+  } catch (err) {
+    return failure(err as Error);
+  }
+};

--- a/frontend/src/js/admin/saveStream.ts
+++ b/frontend/src/js/admin/saveStream.ts
@@ -1,0 +1,53 @@
+import { Result, failure, success } from '../helpers/result';
+import { AccessDenied } from '../helpers/AccessDenied';
+import { AdminTags } from './fetchStreams';
+
+export interface TagEdits {
+  title?: string;
+  // Omitted entirely when the field is blank. A stream with no multiview:order tag
+  // is a supported state (getOrderFromTag defaults it), and sending '' would fail
+  // validation on every save, even one that only changed the title.
+  order?: string;
+  show: boolean;
+  demo: string | null;
+}
+
+export interface SavedStream {
+  tags: AdminTags;
+  refreshed: boolean;
+}
+
+interface SaveResponseOk {
+  ok: true;
+  refreshed: boolean;
+  stream: { id: string; tags: AdminTags };
+}
+
+interface SaveResponseError {
+  ok: false;
+  error: string;
+}
+
+export const saveStream = async (id: string, edits: TagEdits): Promise<Result<Error, SavedStream>> => {
+  try {
+    const fetchResponse = await fetch(`/api/admin/streams/${encodeURIComponent(id)}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(edits),
+    });
+
+    const body = (await fetchResponse.json()) as SaveResponseOk | SaveResponseError;
+
+    if (body.ok === false) {
+      if (fetchResponse.status === 403) {
+        throw new AccessDenied(body.error, fetchResponse.status);
+      }
+      throw new Error(body.error);
+    }
+
+    return success({ tags: body.stream.tags, refreshed: body.refreshed });
+  } catch (err) {
+    return failure(err as Error);
+  }
+};

--- a/infra/main-stack/deployment.cfn.yaml
+++ b/infra/main-stack/deployment.cfn.yaml
@@ -106,6 +106,24 @@ Resources:
       Roles:
         - !Ref "BackendLambdaRole"
 
+  # Separate from CanReadFromSSM so tagging stays scoped to the mux parameters --
+  # the admin UI has no reason to retag the ably or attend secrets.
+  CanTagMuxParameters:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "CanTagMuxParameters"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "ssm:AddTagsToResource"
+              - "ssm:RemoveTagsFromResource"
+            Resource:
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/multiview/mux/*"
+      Roles:
+        - !Ref "BackendLambdaRole"
+
   BackendGetStreamFn:
     Type: AWS::Lambda::Function
     Properties:
@@ -172,6 +190,45 @@ Resources:
         Variables:
           CACHE_TABLE_NAME: !Ref "CacheTable"
           ABLY_CLIENT_KEY: "/multiview/ably/client"
+          ATTEND_JWT_PRIVATE_KEY: "/multiview/attend/ATTEND_JWT_PRIVATE_KEY"
+          ATTEND_JWT_ISSUER: !Ref "AttendJWTIssuer"
+          ATTEND_JWT_AUDIENCE: !Ref "AttendJWTAudience"
+          ATTEND_JWT_REQUIRED_ROLE: 826205
+
+  BackendAdminListStreamsFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref BackendLambdaS3Bucket
+        S3Key: !Ref BackendLambdaS3Key
+      Handler: src/index.adminListStreams
+      Role: !GetAtt "BackendLambdaRole.Arn"
+      Runtime: "nodejs24.x"
+      Timeout: 25
+      Environment:
+        Variables:
+          CACHE_TABLE_NAME: !Ref "CacheTable"
+          ATTEND_JWT_PRIVATE_KEY: "/multiview/attend/ATTEND_JWT_PRIVATE_KEY"
+          ATTEND_JWT_ISSUER: !Ref "AttendJWTIssuer"
+          ATTEND_JWT_AUDIENCE: !Ref "AttendJWTAudience"
+          ATTEND_JWT_REQUIRED_ROLE: 826205
+
+  BackendAdminUpdateStreamFn:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref BackendLambdaS3Bucket
+        S3Key: !Ref BackendLambdaS3Key
+      Handler: src/index.adminUpdateStream
+      Role: !GetAtt "BackendLambdaRole.Arn"
+      Runtime: "nodejs24.x"
+      Timeout: 25
+      Environment:
+        Variables:
+          CACHE_TABLE_NAME: !Ref "CacheTable"
+          # Load-bearing: without it getAblyClient returns undefined and the
+          # publish is silently skipped, so monitors would not update live.
+          ABLY_SERVER_KEY: "/multiview/ably/server"
           ATTEND_JWT_PRIVATE_KEY: "/multiview/attend/ATTEND_JWT_PRIVATE_KEY"
           ATTEND_JWT_ISSUER: !Ref "AttendJWTIssuer"
           ATTEND_JWT_AUDIENCE: !Ref "AttendJWTAudience"
@@ -255,6 +312,8 @@ Resources:
                   - !GetAtt BackendListRoomsFn.Arn
                   - !GetAtt BackendRefreshFn.Arn
                   - !GetAtt BackendDevtokenFn.Arn
+                  - !GetAtt BackendAdminListStreamsFn.Arn
+                  - !GetAtt BackendAdminUpdateStreamFn.Arn
                   - !GetAtt BackendMuxFn.Arn
                   - !GetAtt BackendAblyKeySlFn.Arn
                   - !Sub "${BackendAblyKeySlFn.Arn}:live"
@@ -364,6 +423,48 @@ Resources:
       RouteKey: GET /devtoken
       Target: !Sub "integrations/${BackendDevtokenIntegration}"
 
+  BackendAdminListStreamsIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref BackendAPI
+      Description: "Admin: list streams"
+      ConnectionType: INTERNET
+      CredentialsArn: !GetAtt "BackendAPIRole.Arn"
+      PassthroughBehavior: "WHEN_NO_MATCH"
+      TimeoutInMillis: 29000
+      IntegrationMethod: "POST"
+      IntegrationType: "AWS_PROXY"
+      PayloadFormatVersion: "2.0"
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendAdminListStreamsFn.Arn}/invocations"
+
+  BackendAdminListStreamsRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref BackendAPI
+      RouteKey: GET /admin/streams
+      Target: !Sub "integrations/${BackendAdminListStreamsIntegration}"
+
+  BackendAdminUpdateStreamIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref BackendAPI
+      Description: "Admin: update stream tags"
+      ConnectionType: INTERNET
+      CredentialsArn: !GetAtt "BackendAPIRole.Arn"
+      PassthroughBehavior: "WHEN_NO_MATCH"
+      TimeoutInMillis: 29000
+      IntegrationMethod: "POST"
+      IntegrationType: "AWS_PROXY"
+      PayloadFormatVersion: "2.0"
+      IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendAdminUpdateStreamFn.Arn}/invocations"
+
+  BackendAdminUpdateStreamRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref BackendAPI
+      RouteKey: POST /admin/streams/{muxTokenId}
+      Target: !Sub "integrations/${BackendAdminUpdateStreamIntegration}"
+
   BackendMuxIntegration:
     Type: AWS::ApiGatewayV2::Integration
     Properties:
@@ -438,6 +539,10 @@ Resources:
       - BackendRefreshIntegration
       - BackendDevtokenRoute
       - BackendDevtokenIntegration
+      - BackendAdminListStreamsRoute
+      - BackendAdminListStreamsIntegration
+      - BackendAdminUpdateStreamRoute
+      - BackendAdminUpdateStreamIntegration
       - BackendMuxRoute
       - BackendMuxIntegration
       - BackendAblyKeyRoute


### PR DESCRIPTION
Adds a role-gated page for editing the `multiview:*` SSM tags on existing `/multiview/mux/*` parameters, so streams can be retitled, reordered, shown/hidden and switched to a demo mid-event without AWS console access.

Design: `docs/superpowers/specs/2026-08-14-stream-admin-ui-design.md`

## What's here

- `GET /admin/streams` — every parameter under `/multiview/mux/` with its tags, **unfiltered and paginated**. Unlike `/api/stream` it does not drop `multiview:show != true`, otherwise a room you'd just hidden would vanish from the editor. Parameter values are Mux token secrets and never enter the response type.
- `POST /admin/streams/{muxTokenId}` — validates the edit, writes the tags, then force-refreshes the rooms cache *and* that room's stream cache, and publishes to Ably so open monitors update without a reload. `/api/refresh` only does the first of those, which would leave a demo or title change stale for up to 60s.
- `frontend/src/admin.html` — one editable row per stream, saved independently.
- `helpers/requireRole.ts` — the role check extracted from `devtoken.ts` and shared by all three endpoints.

Both endpoints gate on `ATTEND_JWT_REQUIRED_ROLE`, same as `/api/devtoken`.

## Decisions worth a look

**Attendee distribution only.** The page is reachable at `live.aws.nextdayvideo.com.au/admin.html`. The monitor distribution's `/api/*` behaviour sets no `OriginRequestPolicy` and so forwards no cookies — deliberately, since it's for unauthenticated on-site use. The shared S3 bucket means `admin.html` will also *load* on the monitor domain, where every API call will fail; the page says so in its header rather than adding infra to block it.

**Nothing after the SSM write is fatal.** Once the tags are committed the save has succeeded, so a cache-refresh or Ably failure is logged and returned as `refreshed: false` on a 200, not a 500. This is not hypothetical: `getStreamStateFromDynamo` reaches Mux, so clearing `multiview:demo` on a stream that isn't currently live would otherwise report a failed save that actually landed.

**Tags are read before they're written.** SSM does not document whether `RemoveTagsFromResource` is a no-op for a key that isn't present, and clearing the title of a never-titled stream sends exactly that. Rather than assume, the handler reads current tags and filters removals to keys that exist. It also turns an unknown `muxTokenId` into a 404 instead of a 500.

**`@swc/jest`, not the pre-existing `ts-jest` devDependency.** ts-jest 29 can't drive the TypeScript 7 compiler API this project pins. Downgrading TypeScript is the wrong fix; this matches the transform `frontend/jest.config.js` already uses. Test files are excluded from `tsconfig` so they're never emitted into `dist/` and can't ship inside `build.zip`.

**`ci/pr.sh` now runs `pnpm test`.** It only ran `pnpm run build`, so the new suite would have gated nothing — the frontend's script already runs its tests.

**Tagging permissions are a new `CanTagMuxParameters` policy** rather than an addition to `CanReadFromSSM`, whose resource list also covers the ably and attend secrets.

## What is and isn't verified

Passing locally: `tsc --noEmit` in both projects, 15/15 jest tests on the tag validation, prettier on all new files, and a structural check of the CloudFormation template (YAML parses; both functions, integrations, routes, the four `DependsOn` entries and the two `BackendAPIRole` ARNs all present; CFN handler strings match the `index.ts` exports).

Not verified, and worth knowing before merging:

- **No AWS call was made at all** — no SSM, Lambda, or real CloudFormation validation. IAM changes, route wiring and runtime behaviour are unexercised until this deploys.
- **The Parcel build never ran.** This checkout's `frontend/node_modules` is missing `postcss`, and the registry is unreachable from where this was written. `tsc` and prettier cover the TypeScript; the HTML/Tailwind pipeline is only covered by CI. Tailwind's content glob (`./src/**/*.{html,js,ts,jsx,tsx}`) does cover both new files.
- **`RemoveTagsFromResource` on an absent key is unresolved by design**, not assumed — see above.

The end-to-end pass in Task 7 of `docs/superpowers/plans/2026-08-14-stream-admin-ui.md` lists the specific cases to try once this is deployed, including the two regression-prone ones (a stream with no `multiview:order`, and clearing a demo on a stream that isn't live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)